### PR TITLE
CHAOS-33 delete campaign

### DIFF
--- a/backend/src/campaigns.rs
+++ b/backend/src/campaigns.rs
@@ -1,15 +1,12 @@
 use crate::database::{
-    models::{
-        Campaign, NewOrganisation, Organisation, OrganisationAdmin, OrganisationUser, Role,
-        SuperUser, UpdateCampaignInput, User,
-    },
+    models::{Campaign, OrganisationAdmin, OrganisationUser, Role, UpdateCampaignInput, User},
     schema::AdminLevel,
     Database,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-use rocket::{delete, form::Form, get, post, put, serde::json::Json};
+use rocket::{delete, form::Form, get, put, serde::json::Json};
 
 #[derive(Serialize)]
 pub enum CampaignError {
@@ -48,7 +45,6 @@ pub async fn create_or_update_campaign(
         .run(move |conn| OrganisationUser::get(conn, campaign.organisation_id, user.id))
         .await
         .ok_or(Json(CampaignError::Unauthorized))?;
-
 
     // only allow update if admin_level is not AdminLevel::ReadOnly
     // ie only director, Admin (exec) or SuperUser can perform this action

--- a/backend/src/database/models.rs
+++ b/backend/src/database/models.rs
@@ -37,6 +37,16 @@ impl SuperUser {
     }
 }
 
+pub struct OrganisationDirector {
+    user: User,
+    org: Organisation,
+};
+
+pub struct OrganisationAdmin {
+    user: User,
+    org: Organisation,
+};
+
 #[derive(Insertable)]
 #[table_name = "users"]
 pub struct NewUser {

--- a/backend/src/database/schema.rs
+++ b/backend/src/database/schema.rs
@@ -1,6 +1,6 @@
 use diesel_derive_enum::DbEnum;
 
-#[derive(Debug, DbEnum)]
+#[derive(Debug, DbEnum, PartialEq)]
 pub enum ApplicationStatus {
     Pending,
     Rejected,

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -50,6 +50,7 @@ async fn main() {
                 campaigns::get_campaign,
                 campaigns::create_or_update_campaign,
                 campaigns::roles,
+                campaigns::delete_campaign,
             ],
         )
         .mount("/user", routes![user::get_user])

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -8,6 +8,7 @@ pub mod database;
 pub mod guard;
 pub mod organisation;
 pub mod state;
+pub mod user;
 
 use auth::Auth;
 use cors::cors;
@@ -48,9 +49,10 @@ async fn main() {
             routes![
                 campaigns::get_campaign,
                 campaigns::create_or_update_campaign,
-                campaigns::roles
+                campaigns::roles,
             ],
         )
+        .mount("/user", routes![user::get_user])
         .launch()
         .await
         .unwrap();

--- a/backend/src/user.rs
+++ b/backend/src/user.rs
@@ -1,0 +1,39 @@
+use crate::database::{models::User, Database};
+use rocket::{
+    get,
+    serde::{json::Json, Serialize},
+};
+
+#[derive(Serialize)]
+pub enum UserError {
+    UserNotFound,
+}
+
+#[derive(Serialize)]
+pub struct UserResponse {
+    email: String,
+    zid: String,
+    display_name: String,
+    degree_name: String,
+    degree_starting_year: i32,
+}
+
+#[get("/<user_id>")]
+pub async fn get_user(
+    user_id: i32,
+    _user: User,
+    db: Database,
+) -> Result<Json<UserResponse>, Json<UserError>> {
+    let res: Option<User> = db.run(move |conn| User::get_from_id(&conn, user_id)).await;
+
+    match res {
+        Some(user) => Ok(Json(UserResponse {
+            email: user.email,
+            zid: user.zid,
+            display_name: user.display_name,
+            degree_name: user.degree_name,
+            degree_starting_year: user.degree_starting_year,
+        })),
+        None => Err(Json(UserError::UserNotFound)),
+    }
+}


### PR DESCRIPTION

Did not choose to shallow delete, as it makes filtering and future queries a pain in the ass.

We can simply take backups instead. 

This should delete a campaign and all relevant data. 