### PR TITLE
[CHAOS-16] Add page for finalising candidates after ranking them

### DIFF
--- a/frontend/src/pages/finalise_candidates/finaliseCandidates.styled.js
+++ b/frontend/src/pages/finalise_candidates/finaliseCandidates.styled.js
@@ -1,0 +1,7 @@
+import { styled } from "@mui/material/styles";
+
+export const FinalisedEntry = styled("li")`
+  .name {
+    font-weight: lighter;
+  }
+`;

--- a/frontend/src/pages/finalise_candidates/index.js
+++ b/frontend/src/pages/finalise_candidates/index.js
@@ -1,5 +1,6 @@
-import React from "react";
-import { Container, Grid, Typography } from "@mui/material";
+import React, { useState } from "react";
+import { Box, Container, Grid, Tab, Typography } from "@mui/material";
+import { TabContext, TabList, TabPanel } from "@mui/lab";
 import { FinalisedEntry } from "./finaliseCandidates.styled";
 
 const dummyCandidates = [
@@ -31,6 +32,8 @@ const FinaliseCandidates = () => {
   const notFinalised = dummyCandidates.filter(
     (candidate) => !candidate.finalised
   );
+  // TODO: CHAOS-71 generate tabs and emails for each finalised member
+  const [tab, setTab] = useState("0");
   return (
     <Container>
       <Grid container spacing={2} p={2}>
@@ -38,7 +41,7 @@ const FinaliseCandidates = () => {
           <Typography variant="h2">Finalised</Typography>
           <ul>
             {finalised.map((candidate) => (
-              <FinalisedEntry>
+              <FinalisedEntry key={candidate.role}>
                 {candidate.role} -{" "}
                 <span className="name">{candidate.name}</span>
               </FinalisedEntry>
@@ -49,11 +52,23 @@ const FinaliseCandidates = () => {
           <Typography variant="h2">Not Finalised</Typography>
           <ul>
             {notFinalised.map((candidate) => (
-              <li>{candidate.role}</li>
+              <li key={candidate.role}>{candidate.role}</li>
             ))}
           </ul>
         </Grid>
       </Grid>
+      <TabContext value={tab}>
+        <Box sx={{ border: 1, borderColor: "divider", borderRadius: 1 }}>
+          <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+            <TabList onChange={(_, t) => setTab(t)}>
+              <Tab label="Hayes Choy" value="0" />
+              <Tab label="Shrey Somaiya" value="1" />
+            </TabList>
+          </Box>
+          <TabPanel value="0">email</TabPanel>
+          <TabPanel value="1">poggers</TabPanel>
+        </Box>
+      </TabContext>
     </Container>
   );
 };

--- a/frontend/src/pages/finalise_candidates/index.js
+++ b/frontend/src/pages/finalise_candidates/index.js
@@ -22,7 +22,6 @@ const dummyCandidates = [
   },
   {
     role: "Socials Experience Subcommittee Member",
-    name: "Haley Gu",
     finalised: false,
   },
 ];
@@ -50,9 +49,7 @@ const FinaliseCandidates = () => {
           <Typography variant="h2">Not Finalised</Typography>
           <ul>
             {notFinalised.map((candidate) => (
-              <li>
-                {candidate.role} - {candidate.name}
-              </li>
+              <li>{candidate.role}</li>
             ))}
           </ul>
         </Grid>

--- a/frontend/src/pages/finalise_candidates/index.js
+++ b/frontend/src/pages/finalise_candidates/index.js
@@ -1,0 +1,64 @@
+import React from "react";
+import { Container, Grid, Typography } from "@mui/material";
+import { FinalisedEntry } from "./finaliseCandidates.styled";
+
+const dummyCandidates = [
+  {
+    role: "Student Experience Subcommittee Member",
+    name: "Hayes Choy",
+    finalised: true,
+  },
+  { role: "Media Subcommittee Member", name: "Shrey Somaiya", finalised: true },
+  {
+    role: "Creative Subcommittee Member",
+    name: "Giuliana De Bellis",
+    finalised: true,
+  },
+  { role: "Marketing Subcommittee Member", name: "Colin Hou", finalised: true },
+  {
+    role: "Competitions Subcommittee Member",
+    name: "Lachlan Ting",
+    finalised: true,
+  },
+  {
+    role: "Socials Experience Subcommittee Member",
+    name: "Haley Gu",
+    finalised: false,
+  },
+];
+
+const FinaliseCandidates = () => {
+  const finalised = dummyCandidates.filter((candidate) => candidate.finalised);
+  const notFinalised = dummyCandidates.filter(
+    (candidate) => !candidate.finalised
+  );
+  return (
+    <Container>
+      <Grid container spacing={2} p={2}>
+        <Grid item xs={6}>
+          <Typography variant="h2">Finalised</Typography>
+          <ul>
+            {finalised.map((candidate) => (
+              <FinalisedEntry>
+                {candidate.role} -{" "}
+                <span className="name">{candidate.name}</span>
+              </FinalisedEntry>
+            ))}
+          </ul>
+        </Grid>
+        <Grid item xs={6}>
+          <Typography variant="h2">Not Finalised</Typography>
+          <ul>
+            {notFinalised.map((candidate) => (
+              <li>
+                {candidate.role} - {candidate.name}
+              </li>
+            ))}
+          </ul>
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default FinaliseCandidates;

--- a/frontend/src/pages/rankings/index.js
+++ b/frontend/src/pages/rankings/index.js
@@ -1,4 +1,5 @@
 import React, { useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Container, Button, Grid, Typography } from "@mui/material";
 import { red, green } from "@mui/material/colors";
 
@@ -90,6 +91,7 @@ const dummyRankings = {
 const dummyPositions = Object.keys(dummyRankings);
 
 const Rankings = () => {
+  const navigate = useNavigate();
   const setNavBarTitle = useContext(SetNavBarTitleContext);
   useEffect(() => {
     setNavBarTitle("2022 Subcommittee Recruitment (Hardcoded Title)");
@@ -103,6 +105,7 @@ const Rankings = () => {
       "Order:",
       rankings[selectedPosition].map((candidate) => candidate.name)
     );
+    navigate("/finalise_candidates");
   };
 
   return (

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -7,6 +7,7 @@ const AuthSuccess = lazy(() => import("./pages/auth_success"));
 const SignupPage = lazy(() => import("./pages/signup"));
 const Marking = lazy(() => import("./pages/marking"));
 const Rankings = lazy(() => import("./pages/rankings"));
+const FinaliseCandidates = lazy(() => import("./pages/finalise_candidates"));
 const Admin = lazy(() => import("./pages/admin"));
 const CampaignCreate = lazy(() => import("./pages/create_campaign"));
 const ApplicationPage = lazy(() => import("./pages/application_page"));
@@ -18,6 +19,11 @@ const routes = [
   <Route key="landing" path="/" element={<LandingPage />} />,
   <Route key="marking" path="/marking" element={<Marking />} />,
   <Route key="rankings" path="/rankings" element={<Rankings />} />,
+  <Route
+    key="finalise-candidates"
+    path="/finalise_candidates"
+    element={<FinaliseCandidates />}
+  />,
   <Route key="Admin" path="/Admin" element={<Admin />} />,
   <Route
     key="create-campaign"


### PR DESCRIPTION
This adds a page for finalising candidates after ranking them.

This page currently just uses hardcoded dummy data, this will have to be changed to use the data from the rankings using some sort of state management.

The page has a preview area for generated emails with tabs for each member. This will have to be integrated with the data to render tabs for each candidate, and implement the email generation.