### PR TITLE
[CHAOS101] extract navbar title context into own module

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -25,5 +25,12 @@
         "unnamedComponents": "arrow-function"
       }
     ]
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "moduleDirectory": ["node_modules", "src/"]
+      }
+    }
   }
 }

--- a/frontend/jsconfig.json
+++ b/frontend/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "src"
+  },
+  "include": ["src"]
+}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes } from "react-router-dom";
 import { SnackbarProvider } from "notistack";
 import { CssBaseline, ThemeProvider, createTheme } from "@mui/material";
 import { NavBar, LoadingIndicator } from "./components";
+import { SetNavBarTitleContext } from "./contexts/SetNavbarTitleContext";
 import routes from "./routes";
 
 const theme = createTheme({
@@ -27,8 +28,6 @@ const theme = createTheme({
     },
   },
 });
-
-export const SetNavBarTitleContext = createContext(() => {});
 
 const App = () => {
   const [AppBarTitle, setNavBarTitle] = useState("");

--- a/frontend/src/pages/admin/index.js
+++ b/frontend/src/pages/admin/index.js
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState, createContext } from "react";
-import { SetNavBarTitleContext } from "../../App";
+import { SetNavBarTitleContext } from "contexts/SetNavbarTitleContext";
 import { AdminContainer } from "./admin.styled";
 import AdminSidebar from "../../components/AdminSideBar";
 import AdminContent from "../../components/AdminContent";

--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect, useState } from "react";
 import { Container } from "@mui/material";
+import { SetNavBarTitleContext } from "contexts/SetNavbarTitleContext";
 import CampaignGrid from "./CampaignGrid";
-import { SetNavBarTitleContext } from "../../App";
 
 import { getAllCampaigns } from "../../api";
 

--- a/frontend/src/pages/landing/index.js
+++ b/frontend/src/pages/landing/index.js
@@ -2,9 +2,9 @@ import { Button } from "@mui/material";
 import React, { useContext, useEffect } from "react";
 import { Box } from "@mui/system";
 import { useNavigate } from "react-router-dom";
+import { SetNavBarTitleContext } from "contexts/SetNavbarTitleContext";
 import { BackgroundWrapper, ParticleWallpaper } from "../../components";
 import { BoldTitle, Subtitle } from "./landing.styled";
-import { SetNavBarTitleContext } from "../../App";
 import { getStore } from "../../utils";
 
 const OAUTH_CALLBACK_URL =

--- a/frontend/src/pages/marking/index.js
+++ b/frontend/src/pages/marking/index.js
@@ -3,9 +3,9 @@ import { Box, Container, Button, Grid, Tab } from "@mui/material";
 import { TabContext, TabList, TabPanel } from "@mui/lab";
 
 import { Link, useParams } from "react-router-dom";
+import { SetNavBarTitleContext } from "contexts/SetNavbarTitleContext";
 import ReviewerStepper from "../../components/ReviewerStepper";
 import ApplicationsList from "./ApplicationsList";
-import { SetNavBarTitleContext } from "../../App";
 import {
   getApplicationAnswers,
   getApplicationRatings,

--- a/frontend/src/pages/rankings/index.js
+++ b/frontend/src/pages/rankings/index.js
@@ -3,10 +3,10 @@ import { useNavigate, useParams } from "react-router-dom";
 import { Container, Button, Grid, Typography } from "@mui/material";
 import { red, green } from "@mui/material/colors";
 
+import { SetNavBarTitleContext } from "contexts/SetNavbarTitleContext";
 import RankingsToolbar from "./RankingsToolbar";
 import DragDropRankings from "./DragDropRankings";
 import ReviewerStepper from "../../components/ReviewerStepper";
-import { SetNavBarTitleContext } from "../../App";
 import {
   getApplicationAnswers,
   getApplicationRatings,


### PR DESCRIPTION
resolves the dependency cycles created by having to import the context from `App.js` (routes.js was a middle man in these cycles)