### PR TITLE
[CHAOS-109] fix auth_success error handling

### DIFF
--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -2,7 +2,7 @@ const API_URL = process.env.REACT_APP_API_BASE_URL;
 
 // takes in an object
 const API = {
-  request: async ({ path, body, header, queries = {}, method = "GET" }) => {
+  request: ({ path, body, header, queries = {}, method = "GET" }) => {
     const endpoint = new URL(`${API_URL}${path}`);
     endpoint.search = new URLSearchParams(queries);
 

--- a/frontend/src/pages/auth_success/index.js
+++ b/frontend/src/pages/auth_success/index.js
@@ -27,6 +27,7 @@ const AuthSuccess = () => {
         } catch (err) {
           setError(err);
           setIsLoading(false);
+          return;
         }
 
         if (data[SIGNUP_REQUIRED]) {

--- a/frontend/src/pages/auth_success/index.js
+++ b/frontend/src/pages/auth_success/index.js
@@ -13,7 +13,7 @@ const AuthSuccess = () => {
   const [isAuthenticated, setIsAuthenticated] = React.useState(false);
   const [needsSignup, setNeedsSignup] = React.useState(false);
   const [isLoading, setIsLoading] = React.useState(true);
-  const [error, setError] = React.useState(null);
+  const [error, setError] = React.useState({ message: null });
 
   useEffect(() => {
     async function attemptAuth() {

--- a/frontend/src/pages/auth_success/index.js
+++ b/frontend/src/pages/auth_success/index.js
@@ -25,6 +25,7 @@ const AuthSuccess = () => {
           const res = await authenticate(code);
           data = await res.json();
         } catch (err) {
+          console.error(err);
           setError(err);
           setIsLoading(false);
           return;

--- a/frontend/src/pages/auth_success/index.js
+++ b/frontend/src/pages/auth_success/index.js
@@ -25,8 +25,8 @@ const AuthSuccess = () => {
           const res = await authenticate(code);
           data = await res.json();
         } catch (err) {
-          setIsLoading(false);
           setError(err);
+          setIsLoading(false);
         }
 
         if (data[SIGNUP_REQUIRED]) {

--- a/frontend/src/pages/auth_success/index.js
+++ b/frontend/src/pages/auth_success/index.js
@@ -60,7 +60,7 @@ const AuthSuccess = () => {
     ) : (
       <div>
         <h1>Not Authenticated</h1>
-        {error.message}
+        Error: {error.message}
       </div>
     );
 

--- a/frontend/src/pages/auth_success/index.js
+++ b/frontend/src/pages/auth_success/index.js
@@ -13,31 +13,32 @@ const AuthSuccess = () => {
   const [isAuthenticated, setIsAuthenticated] = useState(false);
   const [needsSignup, setNeedsSignup] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState({ message: null });
+  const [error, setError] = useState({ message: "" });
 
   useEffect(() => {
     async function attemptAuth() {
       const code = query.get("code");
       console.log(code);
       if (code) {
-        await authenticate(code)
-          .then((res) => res.json())
-          .then((data) => {
-            if (data[SIGNUP_REQUIRED]) {
-              setNeedsSignup(true);
-              setIsLoading(false);
-              setStore("name", data[SIGNUP_REQUIRED].name);
-              setStore("signup_token", data[SIGNUP_REQUIRED].signup_token);
-            } else {
-              localStorage.setItem("AUTH_TOKEN", data.token);
-              setIsAuthenticated(true);
-              setIsLoading(false);
-            }
-          })
-          .catch((err) => {
-            setIsLoading(false);
-            setError(err);
-          });
+        let data;
+        try {
+          const res = await authenticate(code);
+          data = await res.json();
+        } catch (err) {
+          setIsLoading(false);
+          setError(err);
+        }
+
+        if (data[SIGNUP_REQUIRED]) {
+          setNeedsSignup(true);
+          setIsLoading(false);
+          setStore("name", data[SIGNUP_REQUIRED].name);
+          setStore("signup_token", data[SIGNUP_REQUIRED].signup_token);
+        } else {
+          localStorage.setItem("AUTH_TOKEN", data.token);
+          setIsAuthenticated(true);
+          setIsLoading(false);
+        }
       }
     }
 

--- a/frontend/src/pages/auth_success/index.js
+++ b/frontend/src/pages/auth_success/index.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { authenticate } from "../../api";
 import { LoadingIndicator } from "../../components";
@@ -10,10 +10,10 @@ const AuthSuccess = () => {
   const query = useQuery();
   const navigate = useNavigate();
 
-  const [isAuthenticated, setIsAuthenticated] = React.useState(false);
-  const [needsSignup, setNeedsSignup] = React.useState(false);
-  const [isLoading, setIsLoading] = React.useState(true);
-  const [error, setError] = React.useState({ message: null });
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [needsSignup, setNeedsSignup] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState({ message: null });
 
   useEffect(() => {
     async function attemptAuth() {


### PR DESCRIPTION
Prior to React 18, multiple state updates within an asynchronous function/promises [are **not** automatically batched](https://github.com/reactwg/react-18/discussions/21), meaning each state update within it causes a separate re-render of the component.

In `AuthSuccess`, we were updating the `isLoading` state *before* the `error` state, so the component would attempt to re-render before the `error` state is updated, which had an initial state of `null`. This caused an error when trying to read the `message` attribute in the render, causing the page to die and never letting it render the error message (and thus completely suppressing the caught error). Giving `error` a proper initial state where this property can be read without error also "fixes" the issue, but it's still a good idea to actually have an accurate error message for the next render before removing the loading state.

In the future, it'd probably be good to migrate to React 18 and avoid these issues in the process