### PR TITLE
[CHAOS-111] remove need for api base url

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@testing-library/react": "12.1.5",
     "@testing-library/user-event": "12.8.3",
     "date-fns": "2.28.0",
+    "http-proxy-middleware": "^2.0.6",
     "notistack": "2.0.5",
     "prop-types": "15.8.1",
     "react": "17.0.2",

--- a/frontend/src/api/api.js
+++ b/frontend/src/api/api.js
@@ -1,9 +1,7 @@
-const API_URL = process.env.REACT_APP_API_BASE_URL;
-
 // takes in an object
 const API = {
   request: ({ path, body, header, queries = {}, method = "GET" }) => {
-    const endpoint = new URL(`${API_URL}${path}`);
+    const endpoint = new URL(`${window.origin}/api${path}`);
     endpoint.search = new URLSearchParams(queries);
 
     const payload = {

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,6 +1,6 @@
 const { createProxyMiddleware } = require("http-proxy-middleware");
 
-module.exports = function (app) {
+module.exports = (app) => {
   app.use(
     "/api",
     createProxyMiddleware({

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -1,0 +1,13 @@
+const { createProxyMiddleware } = require("http-proxy-middleware");
+
+module.exports = function (app) {
+  app.use(
+    "/api",
+    createProxyMiddleware({
+      target: "http://127.0.0.1:8000",
+      pathRewrite: {
+        "^/api/": "/",
+      },
+    })
+  );
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5747,7 +5747,7 @@ http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
-http-proxy-middleware@^2.0.3:
+http-proxy-middleware@^2.0.3, http-proxy-middleware@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz#e1a4dd6979572c7ab5a4e4b55095d1f32a74963f"
   integrity sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==


### PR DESCRIPTION
This removes the use of the `API_BASE_URL` environment variable for the frontend, opting instead to prefix all api requests with `/api/`, and have the development server proxy this to the backend, removing the `/api/` prefix.