### PR TITLE
[CHAOS-126] clear local storage and redirect to home when dashboard fail

### DIFF
--- a/frontend/src/pages/dashboard/index.js
+++ b/frontend/src/pages/dashboard/index.js
@@ -1,11 +1,14 @@
 import React, { useContext, useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Container } from "@mui/material";
+
 import { SetNavBarTitleContext } from "contexts/SetNavbarTitleContext";
+import { removeStore } from "utils";
+import { getAllCampaigns } from "api";
 import CampaignGrid from "./CampaignGrid";
 
-import { getAllCampaigns } from "../../api";
-
 const Dashboard = () => {
+  const navigate = useNavigate();
   const setNavBarTitle = useContext(SetNavBarTitleContext);
   const [myCampaigns, setMyCampaigns] = useState([]);
   const [currentCampaigns, setCurrentCampaigns] = useState([]);
@@ -13,15 +16,27 @@ const Dashboard = () => {
   useEffect(() => {
     setNavBarTitle("Your Dashboard");
 
-    const getCam = async () => {
+    const getCampaigns = async () => {
       const res = await getAllCampaigns();
+      if (!res.ok) {
+        // JWT errors => 400
+        // AccountNoLongerExists => 500
+        if ([400, 500].includes(res.status)) {
+          removeStore("AUTH_TOKEN");
+        } else {
+          console.error(
+            `an error occurred while fetching campaigns (${res.status})`
+          );
+        }
+        navigate("/");
+      }
       const data = await res.json();
       const current = data.current_campaigns;
       setMyCampaigns(current.filter((c) => c.applied_for.length));
       setCurrentCampaigns(current.filter((c) => !c.applied_for.length));
       setPastCampaigns(data.past_campaigns);
     };
-    getCam();
+    getCampaigns();
   }, []);
   return (
     <Container>


### PR DESCRIPTION
trying to only clear local storage if it's an error related to the auth token, in case there's just some temporary unrelated issue with the backend, although this will end up catching a lot of unrelated errors anyway since 500 is included