### PR TITLE
fix(admin-sidebar): move onClick from content to container

### DIFF
--- a/frontend/src/components/AdminSideBar/index.js
+++ b/frontend/src/components/AdminSideBar/index.js
@@ -94,8 +94,8 @@ const AdminSidebar = ({
           )}
         </CreateOrgButton>
         {orgList.map((it, idx) => (
-          <OrgButton value={idx}>
-            <OrgButtonContent onClick={() => setOrgSelected(idx)}>
+          <OrgButton value={idx} onClick={() => setOrgSelected(idx)}>
+            <OrgButtonContent>
               <OrgIcon>
                 <OrgIconImage src={it.icon} />
               </OrgIcon>


### PR DESCRIPTION
Make the sidebar buttons clickable on the edges outside of the content boundaries