### PR TITLE
[CHAOS-140] make navbar always on top

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,7 @@
 import React, { Suspense, useState } from "react";
 import { BrowserRouter, Routes } from "react-router-dom";
 import { SnackbarProvider } from "notistack";
-import { CssBaseline, ThemeProvider, createTheme } from "@mui/material";
+import { Box, CssBaseline, ThemeProvider, createTheme } from "@mui/material";
 import { NavBar, LoadingIndicator } from "./components";
 import { SetNavBarTitleContext } from "./contexts/SetNavbarTitleContext";
 import routes from "./routes";
@@ -39,10 +39,10 @@ const App = () => {
         <Suspense fallback={<LoadingIndicator />}>
           <SetNavBarTitleContext.Provider value={setNavBarTitle}>
             <BrowserRouter>
-              <header>
-                <NavBar campaign={AppBarTitle} />
-              </header>
-              <Routes>{routes}</Routes>
+              <NavBar campaign={AppBarTitle} />
+              <Box pt={8} minHeight="100vh" display="flex">
+                <Routes>{routes}</Routes>
+              </Box>
             </BrowserRouter>
           </SetNavBarTitleContext.Provider>
         </Suspense>

--- a/frontend/src/components/BackgroundWrapper/index.js
+++ b/frontend/src/components/BackgroundWrapper/index.js
@@ -8,11 +8,10 @@ const BackgroundWrapper = ({ children }) => {
     <Box
       sx={{
         display: "flex",
+        flex: 1,
         flexDirection: "column",
         alignItems: "center",
         justifyContent: "center",
-        minHeight: "100vh",
-        minWidth: "100vw",
         backgroundColor: theme.palette.grey[900],
       }}
     >

--- a/frontend/src/components/NavBar/index.js
+++ b/frontend/src/components/NavBar/index.js
@@ -13,7 +13,7 @@ const NavBar = (props) => {
   const navigate = useNavigate();
 
   return (
-    <AppBar position="static">
+    <AppBar position="fixed">
       <Toolbar>
         <LogoButton
           size="large"

--- a/frontend/src/pages/admin/admin.styled.js
+++ b/frontend/src/pages/admin/admin.styled.js
@@ -1,10 +1,8 @@
 import { styled } from "@mui/material/styles";
 
 export const AdminContainer = styled("div")`
-  position: absolute;
   display: flex;
   margin: 0px;
-  height: 100%;
   width: 100%;
   flex-wrap: wrap;
 `;


### PR DESCRIPTION
Landing page looked stupid with particles going on top of the navbar. This fixes that by making the navbar always on top, and also fixes pages being `100vh + 64px` tall and scrolling a bit bc of the navbar offsetting it. We also make the navbar fixed so that if we do need to scroll the page, we can still see the navbar