### PR TITLE
feat: get user display name upon sign in

### DIFF
--- a/backend/server/src/auth.rs
+++ b/backend/server/src/auth.rs
@@ -194,6 +194,7 @@ pub struct SignInBody {
 #[derive(Serialize)]
 pub struct SignInResponse {
     token: String,
+    name: String,
 }
 
 #[derive(Serialize)]
@@ -267,7 +268,7 @@ pub async fn signin(
     )
     .expect("creating jwt should never fail");
 
-    Ok(Json(SignInResponse { token }))
+    Ok(Json(SignInResponse { token, name: user.display_name }))
 }
 
 #[derive(Deserialize, Clone)]

--- a/frontend/src/pages/auth_success/index.jsx
+++ b/frontend/src/pages/auth_success/index.jsx
@@ -37,6 +37,7 @@ const AuthSuccess = () => {
           setStore("name", data[SIGNUP_REQUIRED].name);
           setStore("signup_token", data[SIGNUP_REQUIRED].signup_token);
         } else {
+          localStorage.setItem("name", data.name);
           localStorage.setItem("AUTH_TOKEN", data.token);
           setIsAuthenticated(true);
           setIsLoading(false);


### PR DESCRIPTION
pr train for reasons
relies on #194 (change this pr's target branch to main and rebase after merging #194)

the current behaviour is that upon sign in, we only return the auth token from the backend, and store this in localStorage. signing up however stores both the token and the name. we may want to use the user's name in some parts of the frontend, so this resolves that discrepancy 