### PR TITLE
chore(frontend): add .prettierignore file

### DIFF
--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,2 @@
+dist
+build


### PR DESCRIPTION
add a .prettierignore file with build directories so that `yarn format` doesn't format the built files