### PR TITLE
feat(landing): animate entering cursor capture zone

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "13.4.0",
     "@testing-library/user-event": "14.4.3",
+    "bezier-easing": "2.1.0",
     "date-fns": "2.29.3",
     "http-proxy-middleware": "2.0.6",
     "moment": "2.29.4",

--- a/frontend/src/pages/landing/components/Campaigns/index.jsx
+++ b/frontend/src/pages/landing/components/Campaigns/index.jsx
@@ -27,10 +27,6 @@ const easing = BezierEasing(0.4, 0, 0.2, 1);
 
 const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
   const [multiplier, setMultiplier] = useState(0);
-  const [prevRotateX, setPrevRotateX] = useState(DEFAULT_ROTATE_X);
-  const [prevRotateY, setPrevRotateY] = useState(DEFAULT_ROTATE_Y);
-  const [originX, setOriginX] = useState(DEFAULT_ROTATE_X);
-  const [originY, setOriginY] = useState(DEFAULT_ROTATE_Y);
 
   const withinRange =
     offsetX !== null &&
@@ -53,9 +49,6 @@ const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
       return;
     }
 
-    setOriginX(prevRotateX);
-    setOriginY(prevRotateY);
-
     let done = false;
     let start;
     let previousTimestamp;
@@ -71,13 +64,7 @@ const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
         setMultiplier(Math.min(1, easing(elapsed / duration)));
       }
 
-      if (elapsed >= duration) {
-        setMultiplier(1);
-        return;
-      }
-
-      if (done) {
-        setMultiplier(0);
+      if (elapsed >= duration || done) {
         return;
       }
 
@@ -93,13 +80,8 @@ const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
     };
   }, [withinRange]);
 
-  rotateX = originX + multiplier * (rotateX - originX);
-  rotateY = originY + multiplier * (rotateY - originY);
-
-  useEffect(() => {
-    setPrevRotateX(rotateX);
-    setPrevRotateY(rotateY);
-  }, [rotateX, rotateY]);
+  rotateX = DEFAULT_ROTATE_X + multiplier * (rotateX - DEFAULT_ROTATE_X);
+  rotateY = DEFAULT_ROTATE_Y + multiplier * (rotateY - DEFAULT_ROTATE_Y);
 
   return (
     <Container ref={ref}>

--- a/frontend/src/pages/landing/components/Campaigns/index.jsx
+++ b/frontend/src/pages/landing/components/Campaigns/index.jsx
@@ -46,7 +46,7 @@ const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
   useEffect(() => {
     if (!withinRange) {
       setMultiplier(0);
-      return;
+      return undefined;
     }
 
     let cancel = false;
@@ -74,7 +74,6 @@ const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
 
     window.requestAnimationFrame(step);
 
-    // eslint-disable-next-line consistent-return
     return () => {
       cancel = true;
     };

--- a/frontend/src/pages/landing/components/Campaigns/index.jsx
+++ b/frontend/src/pages/landing/components/Campaigns/index.jsx
@@ -49,7 +49,7 @@ const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
       return;
     }
 
-    let done = false;
+    let cancel = false;
     let start;
     let previousTimestamp;
     const duration = 150;
@@ -64,7 +64,7 @@ const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
         setMultiplier(Math.min(1, easing(elapsed / duration)));
       }
 
-      if (elapsed >= duration || done) {
+      if (elapsed >= duration || cancel) {
         return;
       }
 
@@ -76,7 +76,7 @@ const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
 
     // eslint-disable-next-line consistent-return
     return () => {
-      done = true;
+      cancel = true;
     };
   }, [withinRange]);
 

--- a/frontend/src/pages/landing/components/Campaigns/index.jsx
+++ b/frontend/src/pages/landing/components/Campaigns/index.jsx
@@ -23,6 +23,7 @@ const Row = tw.div`flex gap-6`;
 
 const DEFAULT_ROTATE_X = 6;
 const DEFAULT_ROTATE_Y = -7.5;
+const easing = BezierEasing(0.4, 0, 0.2, 1);
 
 const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
   const [multiplier, setMultiplier] = useState(0);
@@ -67,7 +68,6 @@ const Campaigns = forwardRef(({ offsetX, offsetY }, ref) => {
       const elapsed = timestamp - start;
 
       if (previousTimestamp !== timestamp) {
-        const easing = BezierEasing(0.4, 0, 0.2, 1);
         setMultiplier(Math.min(1, easing(elapsed / duration)));
       }
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1803,6 +1803,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+bezier-easing@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/bezier-easing/-/bezier-easing-2.1.0.tgz#c04dfe8b926d6ecaca1813d69ff179b7c2025d86"
+  integrity sha512-gbIqZ/eslnUFC1tjEvtz0sgx+xTK20wDnYMIA27VA04R7w6xxXQPZDbibjA9DTWZRA2CXtwHykkVzlCaAJAZig==
+
 binary-extensions@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.2.0.tgz#75f502eeaf9ffde42fc98829645be4ea76bd9e2d"


### PR DESCRIPTION
The previous behaviour in the landing page was to only animate the change in 3d rotation when the cursor leaves the capture zone, not entering it. This was because CSS transitions don't work well with continuous minute changes - the transition would reset on every change (every time the cursor position moved), not giving it enough time to update, and hence the rotation would appear stuck while moving the cursor/entering the capture zone.

This implements the animation in JS instead, interpolating the transform values on every frame using `requestAnimationFrame` when the cursor enters the range. This is only done for entering, and we still just use normal CSS transitions for leaving.