### PR TITLE
chore(actions): replace deployment PAT with app dispatch

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -132,7 +132,7 @@ jobs:
       url: https://chaosstaging.devsoc.app
     steps:
       - name: Dispatch deployment
-        uses: devsoc-unsw/deployment-dispatch-action@a115e2ad9226805cd2588dc6fa5b7775991b141a
+        uses: devsoc-unsw/deployment-dispatch-action@main
         with:
           deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
           deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,9 @@ jobs:
     environment:
       name: staging
       url: https://chaos.devsoc.app
+    permissions:
+      contents: read
+      packages: write
     services:
       postgres:
         image: postgres:16
@@ -29,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ github.token }}
       - name: Setup cargo cache
         uses: actions/cache@v3
         with:
@@ -67,7 +70,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ github.token }}
       - name: Build production image
         uses: docker/build-push-action@v4
         with:
@@ -104,7 +107,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ github.token }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
@@ -128,25 +131,11 @@ jobs:
       name: staging
       url: https://chaosstaging.devsoc.app
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
+      - name: Dispatch deployment
+        uses: devsoc-unsw/deployment-dispatch-action@a115e2ad9226805cd2588dc6fa5b7775991b141a
         with:
-          repository: devsoc-unsw/deployment
-          token: ${{ secrets.GH_TOKEN }}
-          ref: dev
-      - name: Install yq - portable yaml processor
-        uses: mikefarah/yq@v4.35.2
-      - name: Update deployment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-        run: |
-          git config user.name "CSESoc CD"
-          git config user.email "technical@csesoc.org.au"
-          git checkout -b update/${{ env.IMAGE_NAME }}/${{ github.sha }}
-          yq -i '.spec.template.spec.containers[0].image = "ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-frontend:${{ github.sha }}"' projects/chaos/${{ env.ENVIRONMENT }}/frontend/deploy.yml
-          yq -i '.spec.template.spec.containers[0].image = "ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-backend:${{ github.sha }}"' projects/chaos/${{ env.ENVIRONMENT }}/backend/deploy.yml
-          git add .
-          git commit -m "feat(${{ env.IMAGE_NAME}}): update images"
-          git push -u origin update/${{ env.IMAGE_NAME }}/${{ github.sha }}
-          gh pr create --title "feat(${{ env.IMAGE_NAME }}): update images" --body "Updates the images for the ${{ env.IMAGE_NAME }} deployment to commit devsoc-unsw/${{ env.IMAGE_NAME}}@${{ github.sha }}." > URL
-          gh pr merge $(cat URL) --squash -d
+          deployment-dispatcher-app-id: ${{ vars.DEPLOYMENT_DISPATCHER_APP_ID }}
+          deployment-dispatcher-app-private-key: ${{ secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY }}
+          updates: |
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-frontend=${{ github.sha }}
+            ghcr.io/devsoc-unsw/${{ env.IMAGE_NAME }}-backend=${{ github.sha }}


### PR DESCRIPTION
## Summary
Use the shared `deployment-dispatch-action` in `.github/workflows/docker.yml` instead of directly checking out and editing `devsoc-unsw/deployment` from this repo's workflow.

## Changes
- replace the current deploy step flow with `devsoc-unsw/deployment-dispatch-action@main`
- rename the app credentials to `vars.DEPLOYMENT_DISPATCHER_APP_ID` and `secrets.DEPLOYMENT_DISPATCHER_APP_PRIVATE_KEY`
- switch GHCR publish authentication to `github.token`
- remove all remaining `GH_TOKEN` and old `IMAGE_UPDATER_*` references from the repo
- keep the existing workflow shape, runner selection, and action versions unless a change was required to remove `GH_TOKEN` or preserve `packages: write` for GHCR publishing

## Context
The action repository currently exposes `main` but does not expose a `v1` tag or `v1` branch, so this PR uses `@main` rather than a pinned commit SHA.

## Verification
- `yq eval '.' .github/workflows/docker.yml > /dev/null`
- `rg -n "\bGH_TOKEN\b|\bIMAGE_UPDATER_APP_ID\b|\bIMAGE_UPDATER_APP_PRIVATE_KEY\b" . -S -g '!node_modules'` returns no matches
- `actionlint -color .github/workflows/docker.yml` still reports pre-existing baseline issues in some repos, such as old major action refs and missing `steps.meta` definitions
