### PR TITLE
Availabilities CRUD

### DIFF
--- a/backend/migrations/20260327105909_interview_module.sql
+++ b/backend/migrations/20260327105909_interview_module.sql
@@ -6,9 +6,10 @@ CREATE TABLE user_campaign_availabilities (
 );
 
 CREATE TABLE availability_slots (
+  id SERIAL PRIMARY KEY,
   availability_id BIGINT NOT NULL REFERENCES user_campaign_availabilities(id) ON DELETE CASCADE,
   start_time TIMESTAMPTZ NOT NULL,
-  PRIMARY KEY (availability_id, start_time)
+  UNIQUE (availability_id, start_time)
 );
 
 CREATE TABLE interview_timeslots (

--- a/backend/migrations/20260327105909_interview_module.sql
+++ b/backend/migrations/20260327105909_interview_module.sql
@@ -1,28 +1,14 @@
 -- Add migration script here
-CREATE TABLE availability (
-    id SERIAL PRIMARY KEY,
+CREATE TABLE user_campaign_availabilities (
+  id BIGINT PRIMARY KEY,
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  campaign_id BIGINT NOT NULL REFERENCES campaigns(id) ON DELETE CASCADE
+);
 
-    user_id INT NOT NULL,
-    role_id INT NOT NULL,
-    campaign_id INT NOT NULL,
-
-    start_time TIMESTAMPTZ NOT NULL,
-    end_time TIMESTAMPTZ NOT NULL,
-
-    CONSTRAINT fk_availability_user
-        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
-
-    CONSTRAINT fk_availability_role
-        FOREIGN KEY (role_id) REFERENCES campaign_roles(id) ON DELETE RESTRICT,
-
-    CONSTRAINT fk_availability_campaign
-        FOREIGN KEY (campaign_id) REFERENCES campaigns(id) ON DELETE CASCADE,
-
-    CONSTRAINT chk_availability_time
-        CHECK (end_time > start_time),
-
-    CONSTRAINT unique_user_availability
-    UNIQUE (user_id, campaign_id, start_time, end_time)
+CREATE TABLE availability_slots (
+  availability_id BIGINT NOT NULL REFERENCES user_campaign_availabilities(id) ON DELETE CASCADE,
+  start_time TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (availability_id, start_time)
 );
 
 CREATE TABLE interview_timeslots (
@@ -70,10 +56,10 @@ CREATE TABLE interview_timeslot_users (
 );
 
 CREATE INDEX idx_availability_campaign
-    ON availability(campaign_id);
+    ON user_campaign_availabilities(campaign_id);
 
 CREATE INDEX idx_availability_user
-    ON availability(user_id);
+    ON user_campaign_availabilities(user_id);
 
 CREATE INDEX idx_timeslots_campaign
     ON interview_timeslots(campaign_id);

--- a/backend/server/src/handler/availabilities.rs
+++ b/backend/server/src/handler/availabilities.rs
@@ -39,7 +39,7 @@ async fn get_or_create_uc_id(
         Availabilities::get_user_campaign_id(user_id, campaign_id, &mut transaction.tx).await;
     Ok(match uc_id_res {
         Err(_) => {
-            Availabilities::create_user_campaign_availabilitty(
+            Availabilities::create_user_campaign_availability(
                 user_id,
                 campaign_id,
                 &mut state.snowflake_generator,
@@ -54,7 +54,7 @@ async fn get_or_create_uc_id(
 impl AvailabilitiesHandler {
     // TODO: change auth_user to an availabilities specific extractor
 
-    /// Retreives all availability slots for a given user_id and campaign_id
+    /// Retrieves all availability slots for a given user_id and campaign_id
     ///
     /// # Arguments
     ///
@@ -77,7 +77,7 @@ impl AvailabilitiesHandler {
     ) -> Result<impl IntoResponse, ChaosError> {
         let uc_id = get_or_create_uc_id(user_id, campaign_id, &mut state, &mut transaction).await?;
 
-        let res = Availabilities::get_availaibility_slots(uc_id, &mut transaction.tx).await?;
+        let res = Availabilities::get_availability_slots(uc_id, &mut transaction.tx).await?;
 
         transaction.tx.commit().await?;
 
@@ -91,7 +91,7 @@ impl AvailabilitiesHandler {
 
     // TODO: change auth_user to an availabilities specific extractor
 
-    /// Modifies availabilities for a given user in a campagin
+    /// Modifies availabilities for a given user in a campaign
     ///
     /// # Arguments
     ///
@@ -117,7 +117,7 @@ impl AvailabilitiesHandler {
         let uc_id = get_or_create_uc_id(user_id, campaign_id, &mut state, &mut transaction).await?;
 
         let curr_availabilities =
-            Availabilities::get_availaibility_slots(uc_id, &mut transaction.tx).await?;
+            Availabilities::get_availability_slots(uc_id, &mut transaction.tx).await?;
 
         // Diff is determined by assuming all current timeslots are to be deleted and none are to be added
         // Since if any availability slot is passed in, then it will either be added (if not already in the db)

--- a/backend/server/src/handler/availabilities.rs
+++ b/backend/server/src/handler/availabilities.rs
@@ -1,0 +1,149 @@
+use std::collections::HashSet;
+
+use axum::{
+    extract::{Json, Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+use crate::models::{
+    app::{AppMessage, AppState, AvailabilitiesMessage},
+    auth::AuthUser,
+    availabilities::{Availabilities, Availability},
+    error::ChaosError,
+    transaction::DBTransaction,
+};
+
+pub struct AvailabilitiesHandler;
+
+/// Gets or creates the user-campaign id, helper function
+///
+/// # Arguments
+/// * `user_id` - ID of the user for the UC pair
+/// * `campaign_id` - ID of the campaign for the UC pair
+/// * `state` - current app state
+/// * `transaction` - the transaction
+///
+/// # Returns
+/// Returns a `Result` containing either
+/// * `Ok(i64)` - the uc id
+/// * `Err(ChaosError)` - If no availabilities are found
+
+async fn get_or_create_uc_id(
+    user_id: i64,
+    campaign_id: i64,
+    state: &mut AppState,
+    transaction: &mut DBTransaction<'_>,
+) -> Result<i64, ChaosError> {
+    let uc_id_res =
+        Availabilities::get_user_campaign_id(user_id, campaign_id, &mut transaction.tx).await;
+    Ok(match uc_id_res {
+        Err(_) => {
+            Availabilities::create_user_campaign_availabilitty(
+                user_id,
+                campaign_id,
+                &mut state.snowflake_generator,
+                &mut transaction.tx,
+            )
+            .await?
+        }
+        Ok(uc) => uc.id,
+    })
+}
+
+impl AvailabilitiesHandler {
+    // TODO: change auth_user to an availabilities specific extractor
+
+    /// Retreives all availability slots for a given user_id and campaign_id
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - ID of the interviewer
+    /// * `campaign_id` - ID of the campaign in which the user will be interviewing
+    /// * `state` - The application state
+    /// * `_auth_user` - The authenticated user
+    /// * `transaction` - Database transaction
+    ///
+    /// # Returns
+    /// Returns a `Result` containing either
+    /// * `Ok(Vec<Availability>)` - Vec of availabilities
+    /// * `Err(ChaosError)` - If no availabilities are found
+
+    pub async fn get_availaibility_slots(
+        Path((user_id, campaign_id)): Path<(i64, i64)>,
+        State(mut state): State<AppState>,
+        _auth_user: AuthUser,
+        mut transaction: DBTransaction<'_>,
+    ) -> Result<impl IntoResponse, ChaosError> {
+        let uc_id = get_or_create_uc_id(user_id, campaign_id, &mut state, &mut transaction).await?;
+
+        let res = Availabilities::get_availaibility_slots(uc_id, &mut transaction.tx).await?;
+
+        transaction.tx.commit().await?;
+
+        Ok((
+            StatusCode::OK,
+            Json(AvailabilitiesMessage {
+                availabilities: res,
+            }),
+        ))
+    }
+
+    // TODO: change auth_user to an availabilities specific extractor
+
+    /// Modifies availabilities for a given user in a campagin
+    ///
+    /// # Arguments
+    ///
+    /// * `user_id` - ID of the interviewer
+    /// * `campaign_id` - ID of the campaign in which the user will be interviewing
+    /// * `availabilities` - the set of ALL availabilities the user now has
+    /// * `state` - The application state
+    /// * `_auth_user` - The authenticated user
+    /// * `transaction` - Database transaction
+    ///
+    /// # Returns
+    /// Returns a `Result` containing either
+    /// * `Ok(())` - If successful
+    /// * `Err(ChaosError)` - Otherwise
+
+    pub async fn modify_availability_slots(
+        Path((user_id, campaign_id)): Path<(i64, i64)>,
+        Json(availabilities): Json<Vec<Availability>>,
+        State(mut state): State<AppState>,
+        _auth_user: AuthUser,
+        mut transaction: DBTransaction<'_>,
+    ) -> Result<impl IntoResponse, ChaosError> {
+        let uc_id = get_or_create_uc_id(user_id, campaign_id, &mut state, &mut transaction).await?;
+
+        let curr_availabilities =
+            Availabilities::get_availaibility_slots(uc_id, &mut transaction.tx).await?;
+
+        // Diff is determined by assuming all current timeslots are to be deleted and none are to be added
+        // Since if any availability slot is passed in, then it will either be added (if not already in the db)
+        // or it won't be removed (if it is already in the db)
+        let mut to_delete: HashSet<Availability> = curr_availabilities.into_iter().collect();
+        let mut to_add: Vec<Availability> = Vec::new();
+
+        availabilities.into_iter().for_each(|a| {
+            if !to_delete.contains(&a) {
+                to_add.push(a);
+            } else {
+                to_delete.remove(&a);
+            }
+        });
+
+        Availabilities::delete_availabilities(
+            user_id,
+            campaign_id,
+            to_delete.into_iter().collect(),
+            &mut transaction.tx,
+        )
+        .await?;
+
+        Availabilities::create_availability_slots(uc_id, to_add, &mut transaction.tx).await?;
+
+        transaction.tx.commit().await?;
+        Ok(AppMessage::OkMessage("Successfully updated availabilities"))
+    }
+}

--- a/backend/server/src/handler/availabilities.rs
+++ b/backend/server/src/handler/availabilities.rs
@@ -69,7 +69,7 @@ impl AvailabilitiesHandler {
     /// * `Ok(Vec<Availability>)` - Vec of availabilities
     /// * `Err(ChaosError)` - If no availabilities are found
 
-    pub async fn get_availaibility_slots(
+    pub async fn get(
         Path((user_id, campaign_id)): Path<(i64, i64)>,
         State(mut state): State<AppState>,
         _auth_user: AuthUser,
@@ -97,8 +97,8 @@ impl AvailabilitiesHandler {
     ///
     /// * `user_id` - ID of the interviewer
     /// * `campaign_id` - ID of the campaign in which the user will be interviewing
-    /// * `availabilities` - the set of ALL availabilities the user now has
     /// * `state` - The application state
+    /// * `availabilities` - the set of ALL availabilities the user now has
     /// * `_auth_user` - The authenticated user
     /// * `transaction` - Database transaction
     ///
@@ -107,12 +107,12 @@ impl AvailabilitiesHandler {
     /// * `Ok(())` - If successful
     /// * `Err(ChaosError)` - Otherwise
 
-    pub async fn modify_availability_slots(
+    pub async fn update(
         Path((user_id, campaign_id)): Path<(i64, i64)>,
-        Json(availabilities): Json<Vec<Availability>>,
         State(mut state): State<AppState>,
         _auth_user: AuthUser,
         mut transaction: DBTransaction<'_>,
+        Json(availabilities): Json<Vec<Availability>>,
     ) -> Result<impl IntoResponse, ChaosError> {
         let uc_id = get_or_create_uc_id(user_id, campaign_id, &mut state, &mut transaction).await?;
 

--- a/backend/server/src/handler/mod.rs
+++ b/backend/server/src/handler/mod.rs
@@ -20,6 +20,7 @@
 pub mod answer;
 pub mod application;
 pub mod auth;
+pub mod availabilities;
 pub mod campaign;
 pub mod comment;
 pub mod email_template;

--- a/backend/server/src/models/app.rs
+++ b/backend/server/src/models/app.rs
@@ -1,6 +1,7 @@
 use crate::handler::answer::AnswerHandler;
 use crate::handler::application::ApplicationHandler;
 use crate::handler::auth::{google_auth_init, google_callback, logout, DevLoginHandler};
+use crate::handler::availabilities::AvailabilitiesHandler;
 use crate::handler::campaign::CampaignHandler;
 use crate::handler::email_template::EmailTemplateHandler;
 use crate::handler::invite::InviteHandler;
@@ -519,6 +520,10 @@ pub async fn app() -> Result<(Router, AppState), ChaosError> {
         .route(
             "/api/v1/invite/:code",
             get(InviteHandler::get).post(InviteHandler::use_invite),
+        )
+        .route(
+            "/api/v1/availabilities/:user_id/:campaign_id",
+            get(AvailabilitiesHandler::get).patch(AvailabilitiesHandler::update),
         )
         .layer(cors)
         .with_state(state);

--- a/backend/server/src/models/app.rs
+++ b/backend/server/src/models/app.rs
@@ -10,6 +10,7 @@ use crate::handler::question::QuestionHandler;
 use crate::handler::rating::RatingHandler;
 use crate::handler::role::RoleHandler;
 use crate::handler::user::UserHandler;
+use crate::models::availabilities::Availability;
 use crate::models::email::{ChaosEmail, EmailCredentials};
 use crate::models::error::ChaosError;
 use crate::models::storage::Storage;
@@ -174,6 +175,11 @@ pub async fn init_app_state() -> AppState {
         is_dev_env,
         email_credentials,
     }
+}
+
+#[derive(Serialize)]
+pub struct AvailabilitiesMessage {
+    pub availabilities: Vec<Availability>,
 }
 
 pub async fn app() -> Result<(Router, AppState), ChaosError> {

--- a/backend/server/src/models/availabilities.rs
+++ b/backend/server/src/models/availabilities.rs
@@ -1,0 +1,244 @@
+use std::ops::DerefMut;
+
+use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use snowflake::SnowflakeIdGenerator;
+use sqlx::{Postgres, Transaction};
+
+use crate::models::error::ChaosError;
+
+#[derive(Deserialize, sqlx::FromRow)]
+pub struct Availability {
+    start_time: DateTime<Utc>,
+}
+
+#[derive(Deserialize, sqlx::FromRow)]
+pub struct UserCampaignId {
+    id: i64,
+}
+
+pub struct AvailabilitiesHandler;
+
+impl AvailabilitiesHandler {
+    // ------------------------- Context -------------------------
+    // `user_campaign_availabilities` and `availability_slots` use a two-table design
+    // to avoid repeating `user_id` and `campaign_id` on every slot row.
+    // Because a single user can submit hundreds of 15-minute availability windows
+    // per campaign,storing those columns once in `availabilities` (one row per
+    // user–campaign pair) and referencing it via FK in `availability_slots` keeps
+    // the slots table narrow and avoids redundant data.
+    //
+    // Note that UC or UC pair as used in this file refers to the data stored
+    // in one row of the user_campaign_availabilities table
+
+    // ------------------------ Operations -----------------------
+
+    /// Creates an ID for a user-campaign availability pair
+    ///
+    /// # Arguments
+    /// * `user_id` - ID of the user interviewer
+    /// * `campaign_id` - ID of the campaign in which the user will be interviewing
+    /// * `snowflake_generator` - A generator for creating unique IDs
+    /// * `transaction` - A mutable reference to the database transaction
+    ///
+    /// # Returns
+    /// Returns a `Result` containing either:
+    /// * `Ok(id)` - If the UC pair was created successfully, where id is its ID
+    /// * `Err(ChaosError)` - If creation fails
+    ///
+
+    pub async fn create_user_campaign_availabilitty(
+        user_id: i64,
+        campaign_id: i64,
+        snowflake_generator: &mut SnowflakeIdGenerator,
+        transaction: &mut Transaction<'_, Postgres>,
+    ) -> Result<(), ChaosError> {
+        let id = snowflake_generator.real_time_generate();
+
+        sqlx::query!(
+            "
+                INSERT INTO user_campaign_availabilities (id, user_id, campaign_id)
+                    VALUES ($1, $2, $3)
+            ",
+            id,
+            user_id,
+            campaign_id
+        )
+        .execute(transaction.deref_mut())
+        .await?;
+
+        Ok(())
+    }
+
+    /// Creates availability slots in bulk for a given user-campaign.
+    /// Designed to create in bulk to avoid multiple calls to the database
+    ///
+    /// # Arguments
+    /// * `availability_id` - ID of the UC pair
+    /// * `availabilities`- Vec of start times, must align to 15min boundaries
+    /// * `transaction` - A mutable reference to the database transaction
+    ///
+    /// # Returns
+    /// Returns a `Result` containing either:
+    /// * `Ok(())` - If ALL the timeslots were successfully created
+    /// * `Err(ChaosError)` - If creation of ANY fails
+
+    pub async fn create_availability_slots(
+        availability_id: i64,
+        availabilities: Vec<Availability>,
+        transaction: &mut Transaction<'_, Postgres>,
+    ) -> Result<(), ChaosError> {
+        let start_times: Vec<DateTime<Utc>> =
+            availabilities.into_iter().map(|a| a.start_time).collect();
+
+        sqlx::query!(
+            "
+                INSERT INTO availability_slots (availability_id, start_time)
+                    SELECT $1, UNNEST($2::timestamptz[])
+            ",
+            availability_id,
+            &start_times as &[DateTime<Utc>]
+        )
+        .execute(transaction.deref_mut())
+        .await?;
+
+        Ok(())
+    }
+
+    /// Gets all available slots for a given UC pair
+    ///
+    /// # Arguments
+    /// * `user_id` - ID of the interviewer
+    /// * `campaign_id` - ID of the campaign in which the user will be interviewing
+    ///
+    /// # Returns
+    /// Returns a `Result` containing either
+    /// * `Ok(Vec<Availabilities>)` - a Vec of all the availabilities
+    /// * `Err(ChaosError)`- If no such user campaign pair found
+
+    pub async fn get_availaibility_slots(
+        user_id: i64,
+        campaign_id: i64,
+        transaction: &mut Transaction<'_, Postgres>,
+    ) -> Result<Vec<Availability>, ChaosError> {
+        let slots = sqlx::query_as!(
+            Availability,
+            "
+                SELECT start_time
+                FROM user_campaign_availabilities uc
+                RIGHT JOIN availability_slots s ON uc.id = s.availability_id
+                WHERE user_id = $1
+                AND campaign_id = $2
+            ",
+            user_id,
+            campaign_id
+        )
+        .fetch_all(transaction.deref_mut())
+        .await?;
+
+        Ok(slots)
+    }
+
+    /// Gets the UC id for a given user_id and campaign id
+    ///
+    /// # Arguments
+    /// * `user_id` - ID of the interviewer
+    /// * `campaign_id` - ID of the campaign in which the user will be interviewing
+    ///
+    /// # Returns
+    /// Returns a `Result` containing either
+    /// * `Ok(i64)` - the UC id
+    /// * `Err(ChaosError)` - If no such user user campaign pair is found
+
+    pub async fn get_user_campaign_id(
+        user_id: i64,
+        campaign_id: i64,
+        transaction: &mut Transaction<'_, Postgres>,
+    ) -> Result<UserCampaignId, ChaosError> {
+        let user_campaign_id = sqlx::query_as!(
+            UserCampaignId,
+            "
+                SELECT id
+                FROM user_campaign_availabilities
+                WHERE user_id = $1
+                AND campaign_id = $2
+            ",
+            user_id,
+            campaign_id
+        )
+        .fetch_one(transaction.deref_mut())
+        .await?;
+
+        Ok(user_campaign_id)
+    }
+
+    /// Deletes the given availability slots for a given user
+    ///
+    /// # Arguments
+    /// * `user_id` - ID of the interviewer
+    /// * `campaign_id` - ID of the campaign in which the user will be interviewing
+    /// * `availabilities`- Vec of start times, must align to 15min boundaries
+    ///
+    /// # Returns
+    /// Returns a `Result` containing either
+    /// * `Ok(())` - if update was successful
+    /// * `Err(ChaosError)` - if update was unsuccessful
+
+    pub async fn delete_availabilities(
+        user_id: i64,
+        campaign_id: i64,
+        availabilities: Vec<Availability>,
+        transaction: &mut Transaction<'_, Postgres>,
+    ) -> Result<(), ChaosError> {
+        let start_times: Vec<DateTime<Utc>> = availabilities.iter().map(|a| a.start_time).collect();
+
+        sqlx::query!(
+            "
+                DELETE FROM availability_slots s
+                USING user_campaign_availabilities uc
+                WHERE uc.id = s.availability_id
+                AND uc.user_id = $1
+                AND uc.campaign_id = $2
+                AND s.start_time = ANY($3::timestamptz[])
+            ",
+            user_id,
+            campaign_id,
+            &start_times as &[DateTime<Utc>]
+        )
+        .execute(transaction.deref_mut())
+        .await?;
+
+        Ok(())
+    }
+
+    /// Deletes a UC pair
+    ///
+    /// # Arguments
+    /// * `user_id` - ID of the interviewer
+    /// * `campaign_id` - ID of the campaign in which the user will be interviewing
+    ///
+    /// # Returns
+    /// Returns a `Result` containing either
+    /// * `Ok(())` - if update was successful
+    /// * `Err(ChaosError)` - if update was unsuccessful
+
+    pub async fn delete_user_campaign(
+        user_id: i64,
+        campaign_id: i64,
+        transaction: &mut Transaction<'_, Postgres>,
+    ) -> Result<(), ChaosError> {
+        sqlx::query!(
+            "
+                DELETE FROM user_campaign_availabilities
+                WHERE user_id = $1
+                AND campaign_id = $2
+            ",
+            user_id,
+            campaign_id
+        )
+        .execute(transaction.deref_mut())
+        .await?;
+
+        Ok(())
+    }
+}

--- a/backend/server/src/models/availabilities.rs
+++ b/backend/server/src/models/availabilities.rs
@@ -1,20 +1,28 @@
-use std::ops::DerefMut;
+use std::{hash::Hash, ops::DerefMut};
 
 use chrono::{DateTime, Utc};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use snowflake::SnowflakeIdGenerator;
 use sqlx::{Postgres, Transaction};
 
 use crate::models::error::ChaosError;
 
-#[derive(Deserialize, sqlx::FromRow)]
+#[derive(Serialize, Deserialize, sqlx::FromRow, PartialEq)]
 pub struct Availability {
     start_time: DateTime<Utc>,
 }
 
+impl Eq for Availability {}
+
+impl Hash for Availability {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.start_time.hash(state);
+    }
+}
+
 #[derive(Deserialize, sqlx::FromRow)]
 pub struct UserCampaignId {
-    id: i64,
+    pub id: i64,
 }
 
 pub struct Availabilities;
@@ -36,7 +44,7 @@ impl Availabilities {
     /// Creates an ID for a user-campaign availability pair
     ///
     /// # Arguments
-    /// * `user_id` - ID of the user interviewer
+    /// * `user_id` - ID of the interviewer
     /// * `campaign_id` - ID of the campaign in which the user will be interviewing
     /// * `snowflake_generator` - A generator for creating unique IDs
     /// * `transaction` - A mutable reference to the database transaction
@@ -52,7 +60,7 @@ impl Availabilities {
         campaign_id: i64,
         snowflake_generator: &mut SnowflakeIdGenerator,
         transaction: &mut Transaction<'_, Postgres>,
-    ) -> Result<(), ChaosError> {
+    ) -> Result<i64, ChaosError> {
         let id = snowflake_generator.real_time_generate();
 
         sqlx::query!(
@@ -67,7 +75,7 @@ impl Availabilities {
         .execute(transaction.deref_mut())
         .await?;
 
-        Ok(())
+        Ok(id)
     }
 
     /// Creates availability slots in bulk for a given user-campaign.
@@ -117,21 +125,17 @@ impl Availabilities {
     /// * `Err(ChaosError)`- If no such user campaign pair found
 
     pub async fn get_availaibility_slots(
-        user_id: i64,
-        campaign_id: i64,
+        availability_id: i64,
         transaction: &mut Transaction<'_, Postgres>,
     ) -> Result<Vec<Availability>, ChaosError> {
         let slots = sqlx::query_as!(
             Availability,
             "
                 SELECT start_time
-                FROM user_campaign_availabilities uc
-                RIGHT JOIN availability_slots s ON uc.id = s.availability_id
-                WHERE user_id = $1
-                AND campaign_id = $2
-            ",
-            user_id,
-            campaign_id
+                FROM availability_slots
+                WHERE availability_id = $1
+                ",
+            availability_id
         )
         .fetch_all(transaction.deref_mut())
         .await?;
@@ -204,37 +208,6 @@ impl Availabilities {
             user_id,
             campaign_id,
             &start_times as &[DateTime<Utc>]
-        )
-        .execute(transaction.deref_mut())
-        .await?;
-
-        Ok(())
-    }
-
-    /// Deletes a UC pair
-    ///
-    /// # Arguments
-    /// * `user_id` - ID of the interviewer
-    /// * `campaign_id` - ID of the campaign in which the user will be interviewing
-    ///
-    /// # Returns
-    /// Returns a `Result` containing either
-    /// * `Ok(())` - if update was successful
-    /// * `Err(ChaosError)` - if update was unsuccessful
-
-    pub async fn delete_user_campaign(
-        user_id: i64,
-        campaign_id: i64,
-        transaction: &mut Transaction<'_, Postgres>,
-    ) -> Result<(), ChaosError> {
-        sqlx::query!(
-            "
-                DELETE FROM user_campaign_availabilities
-                WHERE user_id = $1
-                AND campaign_id = $2
-            ",
-            user_id,
-            campaign_id
         )
         .execute(transaction.deref_mut())
         .await?;

--- a/backend/server/src/models/availabilities.rs
+++ b/backend/server/src/models/availabilities.rs
@@ -17,9 +17,9 @@ pub struct UserCampaignId {
     id: i64,
 }
 
-pub struct AvailabilitiesHandler;
+pub struct Availabilities;
 
-impl AvailabilitiesHandler {
+impl Availabilities {
     // ------------------------- Context -------------------------
     // `user_campaign_availabilities` and `availability_slots` use a two-table design
     // to avoid repeating `user_id` and `campaign_id` on every slot row.

--- a/backend/server/src/models/availabilities.rs
+++ b/backend/server/src/models/availabilities.rs
@@ -55,7 +55,7 @@ impl Availabilities {
     /// * `Err(ChaosError)` - If creation fails
     ///
 
-    pub async fn create_user_campaign_availabilitty(
+    pub async fn create_user_campaign_availability(
         user_id: i64,
         campaign_id: i64,
         snowflake_generator: &mut SnowflakeIdGenerator,
@@ -124,7 +124,7 @@ impl Availabilities {
     /// * `Ok(Vec<Availabilities>)` - a Vec of all the availabilities
     /// * `Err(ChaosError)`- If no such user campaign pair found
 
-    pub async fn get_availaibility_slots(
+    pub async fn get_availability_slots(
         availability_id: i64,
         transaction: &mut Transaction<'_, Postgres>,
     ) -> Result<Vec<Availability>, ChaosError> {

--- a/backend/server/src/models/mod.rs
+++ b/backend/server/src/models/mod.rs
@@ -11,6 +11,7 @@ pub mod answer;
 pub mod app;
 pub mod application;
 pub mod auth;
+pub mod availabilities;
 pub mod campaign;
 pub mod comment;
 pub mod email;


### PR DESCRIPTION
Still need to fix Auth with handlers, handing this off to @Plebbaroni as per conversation in dev session

- 2 Postgres tables for storing availabilities
    - `user_campaign_availabilities` - for `user_id` and `campaign_id`
    - `availability_slots` - for the actual timeslots
    - Done in this way to avoid changing `user_id` and/or `campaign_id` for every timeslot when only one change is needed
- Models that modify these tables
- 2 Handlers calling the models
    - `get` - gets all the timeslots for a given `user_id` and `campaign_id`
    - `update` - given a set of availabilities, updates the database to match for a given `user_id` and `campaign_id`
- "/api/v1/availabilities/:user_id/:campaign_id" route, implementing a `get` and a `patch` router for the corresponding handlers