### PR TITLE
fix: Fixed path parameter extractor usage in RoleStatusHandler

### DIFF
--- a/backend/server/src/handler/role_status.rs
+++ b/backend/server/src/handler/role_status.rs
@@ -26,8 +26,7 @@ impl RoleStatusHandler {
     /// # Returns
     /// A success message.
     pub async fn update_role_status(
-        Path(application_id): Path<i64>,
-        Path(campaign_role_id): Path<i64>,
+        Path((application_id, campaign_role_id)): Path<(i64, i64)>,
         // TODO: Replace the AuthUser extractor with something that enforces the desired permissions.
         _admin: AuthUser,
         mut transaction: DBTransaction<'_>,
@@ -82,8 +81,7 @@ impl RoleStatusHandler {
     /// # Returns
     /// The per-role statuses for the campaign role.
     pub async fn get_role_statuses_for_campaign_role(
-        Path(campaign_id): Path<i64>,
-        Path(campaign_role_id): Path<i64>,
+        Path((campaign_id, campaign_role_id)): Path<(i64, i64)>,
         // TODO: Replace the CampaignOrgMember extractor with something that enforces the desired permissions.
         _admin: CampaignOrgMember,
         mut transaction: DBTransaction<'_>,

--- a/backend/server/src/models/app.rs
+++ b/backend/server/src/models/app.rs
@@ -457,19 +457,19 @@ pub async fn app() -> Result<(Router, AppState), ChaosError> {
             patch(ApplicationHandler::set_private_status),
         )
         .route(
-            "/api/v1/application/:application_id/rolestatus/:campaignRoleId",
+            "/api/v1/application/:application_id/rolestatus/:campaign_role_id",
             put(RoleStatusHandler::update_role_status),
         )
         .route(
-            "/api/v1/application/:applicationId/rolestatus",
+            "/api/v1/application/:application_id/rolestatus",
             get(RoleStatusHandler::get_role_statuses_for_application),
         )
         .route(
-            "/api/v1/campaign/:campaignId/rolestatus/:campaignRoleId`",
+            "/api/v1/campaign/:campaign_id/rolestatus/:campaign_role_id`",
             get(RoleStatusHandler::get_role_statuses_for_campaign_role),
         )
         .route(
-            "/api/v1/campaign/:campaignId/rolestatus`",
+            "/api/v1/campaign/:campaign_id/rolestatus`",
             get(RoleStatusHandler::get_role_statuses_for_campaign),
         )
         .route(


### PR DESCRIPTION
Closes #764 
- Fixes multiple `Path` extractors being used in `RoleStatusHandler` route handlers.
- Corrects camel case typo for per-role status routes in `App` route handler.