### PR TITLE
Upgrade frontend to TypeScript 6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,14 @@
 
 ## Build/Lint/Test Commands
 
-### Frontend (React/TypeScript)
-- **Start dev server**: `cd frontend && yarn start`
-- **Build**: `cd frontend && yarn build`
-- **Lint**: `cd frontend && yarn lint`
-- **Lint fix**: `cd frontend && yarn lint:fix`
-- **Format**: `cd frontend && yarn format`
-- **Type check**: `cd frontend && npx tsc --noEmit`
+### Frontend (Next.js/TypeScript)
+
+- **Start dev server**: `cd frontend-nextjs && bun run dev`
+- **Build**: `cd frontend-nextjs && bun run build`
+- **Start production server**: `cd frontend-nextjs && bun run start`
 
 ### Backend (Rust)
+
 - **Build**: `cd backend/server && cargo build`
 - **Run**: `cd backend/server && cargo run`
 - **Format**: `cd backend/server && cargo fmt`
@@ -18,15 +17,18 @@
 - **Test**: `cd backend/server && cargo test`
 
 ### Database
+
 - **Run migrations**: Run `sqlx migrate run` in `backend` directory
 - **Create new migrations**: Run `sqlx migrate add <name>` e.g. `sqlx migrate add user_settings` in `backend` directory. This will create a file of the format `<time>_name.sql` in `backend/migrations` directory
 
 ## Architecture Overview
 
 ### Backend (Rust/Axum)
+
 The backend follows a clean architecture pattern with three main layers:
 
 **Handler Layer** (`backend/server/src/handler/`):
+
 - Contains HTTP request handlers organized by domain (user, application, campaign, etc.)
 - Each handler module contains structs with methods that process HTTP requests
 - Handlers extract data from requests, call service layer methods, and return responses
@@ -34,6 +36,7 @@ The backend follows a clean architecture pattern with three main layers:
 - Example: `UserHandler` has methods like `get()`, `update_name()`, `update_pronouns()`
 
 **Service Layer** (`backend/server/src/service/`):
+
 - Contains business logic and database operations
 - Each service module handles the core functionality for its domain
 - Services interact directly with the database using SQLx
@@ -43,6 +46,7 @@ The backend follows a clean architecture pattern with three main layers:
 - Includes authentication (JWT, OAuth2), email handling, and file storage
 
 **Model Layer** (`backend/server/src/models/`):
+
 - Contains data structures and database interaction logic
 - Each model represents a database entity with serialization/deserialization
 - Models use SQLx traits like `FromRow` for database mapping
@@ -50,6 +54,7 @@ The backend follows a clean architecture pattern with three main layers:
 - Includes error types, authentication structs, and utility types
 
 **Key Patterns**:
+
 - Database transactions are handled via `DBTransaction` wrapper
 - Authentication uses JWT tokens with Google OAuth2 integration
 - File storage uses S3-compatible services
@@ -76,61 +81,10 @@ The backend follows a clean architecture pattern with three main layers:
   - Request/response schemas with examples
   - Error response definitions
 
-### Frontend (React/TypeScript)
-The frontend follows a component-based architecture with clear separation of concerns:
-
-**Component Structure** (`frontend/src/components/`):
-- Reusable UI components organized by feature (AdminSideBar, CampaignCard, etc.)
-- Styled using twin.macro (Tailwind CSS + Emotion)
-- Components use TypeScript with strict typing
-- Follows atomic design principles with ui/ folder for base components
-
-**Page Structure** (`frontend/src/pages/`):
-- Route-based page components with lazy loading
-- Organized by feature areas (admin, application_page, dashboard, etc.)
-- Each page handles its own state management and API calls
-
-**Context Management** (`frontend/src/contexts/`):
-- React contexts for global state (UserContext, MessagePopupContext)
-- Centralized state management for user authentication and UI state
-
-**API Layer** (`frontend/src/api/`):
-- Centralized API client using fetch with custom error handling
-- Handles large integer serialization to avoid JavaScript precision issues
-- Cookie-based authentication with backend
-- **Large Integer Processing**: Automatically converts i64 IDs from strings to preserve precision:
-  ```typescript
-  // Regex-based processing in API client converts large integers to strings
-  const processedText = text.replace(/"id":(\d{16,})/g, '"id":"$1"')
-  ```
-
-**Key Patterns**:
-- Custom hooks for data fetching and state management
-- Toast notifications for user feedback
-- Form handling with react-hook-form and Zod validation
-- Responsive design with Tailwind CSS
-- Component composition over inheritance
-
 ## Code Style Guidelines
 
-### TypeScript/React (Frontend)
-- **Imports**: Group by builtin → external → internal → parent → sibling → index → object → type. Alphabetize within groups.
-- **Naming**: camelCase for variables/functions, PascalCase for types/components, UPPER_CASE for constants
-- **Types**: Strict TypeScript with `strict: true`, consistent type imports (`import type`)
-- **Components**: Arrow function components, .tsx/.ts extensions only
-- **Formatting**: Prettier with 2-space indentation, 80 char width, double quotes, semicolons
-- **Linting**: Airbnb + TypeScript rules, no console logs in production
-- **ID Field Types**: All ID fields must be `string` type to handle i64 integers from backend:
-  ```typescript
-  export type User = {
-    id: string;        // Not number - handles large i64 values
-    campaign_id: string;
-    organisation_id: string;
-    // ... other fields
-  }
-  ```
-
 ### Rust (Backend)
+
 - **Formatting**: Standard rustfmt (enforced by pre-commit)
 - **Naming**: Standard Rust conventions (snake_case for functions/variables, PascalCase for types)
 - **Error handling**: Use `anyhow` and `thiserror` for consistent error types
@@ -142,16 +96,19 @@ The frontend follows a component-based architecture with clear separation of con
   - Return nested one-to-many relationships as `Vec<sqlx::Json<T>>`
   - Prefer single queries over multiple round trips when possible
 - **i64 ID Handling**: All i64 IDs must be serialized as strings for JavaScript compatibility:
+
   ```rust
   #[serde(serialize_with = "crate::models::serde_string::serialize")]
   #[serde(deserialize_with = "crate::models::serde_string::deserialize")]
   pub id: i64,
   ```
+
   - Use the existing `serde_string` module functions for serialization
   - Frontend TypeScript types must use `string` type for all ID fields
   - This prevents JavaScript Number precision issues with large integers
 
 ### General
+
 - **Pre-commit**: Run `pre-commit install` to enable automatic formatting/linting
 - **No unused vars**: Prefix with `_` to ignore, or remove if truly unused
 - **Security**: Never commit secrets, use environment variables via `.env` files

--- a/frontend-nextjs/bun.lock
+++ b/frontend-nextjs/bun.lock
@@ -55,7 +55,7 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
-        "typescript": "^5.9.3",
+        "typescript": "6.0.3",
       },
     },
   },
@@ -624,7 +624,7 @@
 
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 

--- a/frontend-nextjs/package.json
+++ b/frontend-nextjs/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start -p 3000"
+    "start": "next start -p 3000",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@hello-pangea/dnd": "^18.0.1",
@@ -58,6 +59,6 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",
-    "typescript": "^5.9.3"
+    "typescript": "6.0.3"
   }
 }

--- a/frontend-nextjs/src/types/global.d.ts
+++ b/frontend-nextjs/src/types/global.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "chaos",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
Very small PR, ran codemods that said no changes required. Had to make a fix to allow CSS files to be imported because `noUncheckedSideEffectImports` now defaults to true.

`bun run tsc --noEmit` passes still, LGTM? No eslint yet, so it's a bit hard to see deprecations... (Next PR??? 👀)