### PR TITLE
Chaos 778 hotfix info icon

### DIFF
--- a/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
+++ b/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
@@ -31,7 +31,7 @@ import Image from "next/image";
 
 export default function CampaignSettings({ campaignId, orgId, dict }: { campaignId: string, orgId: string, dict: any }) {
     const queryClient = useQueryClient();
-    const DESCRIPTION_WORD_LIMIT = 100;
+    const DESCRIPTION_CHAR_LIMIT = 200;
 
     const { data: campaign } = useQuery({
         queryKey: [`${campaignId}-campaign-details`],
@@ -126,8 +126,8 @@ export default function CampaignSettings({ campaignId, orgId, dict }: { campaign
     });
 
     const handleCampaignDetailsUpdate = (overrides?: Partial<CampaignUpdate>) => {
-        if (getWordCount(campaignDescription) > DESCRIPTION_WORD_LIMIT) {
-            toast.error(`Description must be under ${DESCRIPTION_WORD_LIMIT} words`);
+        if (campaignDescription.length > DESCRIPTION_CHAR_LIMIT) {
+            toast.error(`Description must be under ${DESCRIPTION_CHAR_LIMIT} characters`);
             return;
         }
         mutateUpdateCampaignDetails({
@@ -202,8 +202,8 @@ export default function CampaignSettings({ campaignId, orgId, dict }: { campaign
                         value={campaignDescription}
                         onChange={(e) => setCampaignDescription(e.target.value)}
                         onBlur={() => handleCampaignDetailsUpdate()} />
-                    <p className={`text-sm mt-1 ${getWordCount(campaignDescription) > DESCRIPTION_WORD_LIMIT ? "text-destructive font-bold" : "text-muted-foreground"}`}>
-                        {getWordCount(campaignDescription)} / {DESCRIPTION_WORD_LIMIT} words
+                    <p className={`text-sm mt-1 ${campaignDescription.length > DESCRIPTION_CHAR_LIMIT ? "text-destructive font-bold" : "text-muted-foreground"}`}>
+                        {campaignDescription.length} / {DESCRIPTION_CHAR_LIMIT} characters
                     </p>
                 </div>
 

--- a/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
+++ b/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
@@ -7,7 +7,7 @@ import { getRatingCategories, createCategory, updateCategory, deleteCategory, Ra
 import { Button } from "@/components/ui/button";
 import { Copy, Pencil, Trash, Share, BookOpenCheck, Check, Plus, FormIcon, CircleCheck, Upload, X, FileText, BarChart, ArrowLeft } from "lucide-react";
 import { ButtonGroup } from "@/components/ui/button-group";
-import { cn } from "@/lib/utils";
+import { cn, getWordCount } from "@/lib/utils";
 import {
     Table,
     TableBody,
@@ -31,6 +31,7 @@ import Image from "next/image";
 
 export default function CampaignSettings({ campaignId, orgId, dict }: { campaignId: string, orgId: string, dict: any }) {
     const queryClient = useQueryClient();
+    const DESCRIPTION_WORD_LIMIT = 100;
 
     const { data: campaign } = useQuery({
         queryKey: [`${campaignId}-campaign-details`],
@@ -125,6 +126,10 @@ export default function CampaignSettings({ campaignId, orgId, dict }: { campaign
     });
 
     const handleCampaignDetailsUpdate = (overrides?: Partial<CampaignUpdate>) => {
+        if (getWordCount(campaignDescription) > DESCRIPTION_WORD_LIMIT) {
+            toast.error(`Description must be under ${DESCRIPTION_WORD_LIMIT} words`);
+            return;
+        }
         mutateUpdateCampaignDetails({
             name: campaignName,
             slug: campaignSlug,
@@ -193,7 +198,13 @@ export default function CampaignSettings({ campaignId, orgId, dict }: { campaign
 
                 <div className="flex flex-col gap-1">
                     <Label htmlFor="campaign-description">{dict.common.description}</Label>
-                    <Textarea className="min-h-[300px]" value={campaignDescription} onChange={(e) => setCampaignDescription(e.target.value)} onBlur={() => handleCampaignDetailsUpdate()} />
+                    <Textarea className="min-h-[300px]"
+                        value={campaignDescription}
+                        onChange={(e) => setCampaignDescription(e.target.value)}
+                        onBlur={() => handleCampaignDetailsUpdate()} />
+                    <p className={`text-sm mt-1 ${getWordCount(campaignDescription) > DESCRIPTION_WORD_LIMIT ? "text-destructive font-bold" : "text-muted-foreground"}`}>
+                        {getWordCount(campaignDescription)} / {DESCRIPTION_WORD_LIMIT} words
+                    </p>
                 </div>
 
                 <div className="flex flex-col gap-1">

--- a/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
+++ b/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
@@ -5,17 +5,7 @@ import { CampaignUpdate, createCampaignRole, getCampaign, getCampaignRoles, upda
 import { uploadFile } from "@/models/file";
 import { getRatingCategories, createCategory, updateCategory, deleteCategory, RatingCategory } from "@/models/rating";
 import { Button } from "@/components/ui/button";
-import { Copy, Pencil, Trash, Share, BookOpenCheck, Check, Plus, FormIcon, CircleCheck, Upload, X, FileText, BarChart, ArrowLeft } from "lucide-react";
-import { ButtonGroup } from "@/components/ui/button-group";
-import { cn, getWordCount } from "@/lib/utils";
-import {
-    Table,
-    TableBody,
-    TableCell,
-    TableHead,
-    TableHeader,
-    TableRow,
-} from "@/components/ui/table"
+import { Plus, Upload, ArrowLeft } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import { Input } from "@/components/ui/input";

--- a/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
+++ b/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
@@ -197,11 +197,16 @@ export default function CampaignSettings({ campaignId, orgId, dict }: { campaign
 
                 <div className="flex flex-col gap-1">
                     <Label htmlFor="campaign-description">{dict.common.description}</Label>
+                    {campaignDescription.length > DESCRIPTION_CHAR_LIMIT && (
+                        <p className={`text-sm mt-1 text-destructive font-medium`}>
+                            Character limit exceeded. Please shorten your description.
+                        </p>
+                    )}
                     <Textarea className="min-h-[300px]"
                         value={campaignDescription}
                         onChange={(e) => setCampaignDescription(e.target.value)}
                         onBlur={() => handleCampaignDetailsUpdate()} />
-                    <p className={`text-sm mt-1 ${campaignDescription.length > DESCRIPTION_CHAR_LIMIT ? "text-destructive font-bold" : "text-muted-foreground"}`}>
+                    <p className={`text-sm mt-1 ${campaignDescription.length > DESCRIPTION_CHAR_LIMIT ? "text-destructive font-medium" : "text-muted-foreground"}`}>
                         {campaignDescription.length} / {DESCRIPTION_CHAR_LIMIT} characters
                     </p>
                 </div>

--- a/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
+++ b/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
@@ -5,7 +5,7 @@ import { CampaignUpdate, createCampaignRole, getCampaign, getCampaignRoles, upda
 import { uploadFile } from "@/models/file";
 import { getRatingCategories, createCategory, updateCategory, deleteCategory, RatingCategory } from "@/models/rating";
 import { Button } from "@/components/ui/button";
-import { Plus, Upload, ArrowLeft } from "lucide-react";
+import { Plus, Upload, ArrowLeft, Trash } from "lucide-react";
 import Link from "next/link";
 import { useState } from "react";
 import { Input } from "@/components/ui/input";

--- a/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
+++ b/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/edit/campaign-settings.tsx
@@ -127,7 +127,6 @@ export default function CampaignSettings({ campaignId, orgId, dict }: { campaign
 
     const handleCampaignDetailsUpdate = (overrides?: Partial<CampaignUpdate>) => {
         if (campaignDescription.length > DESCRIPTION_CHAR_LIMIT) {
-            toast.error(`Description must be under ${DESCRIPTION_CHAR_LIMIT} characters`);
             return;
         }
         mutateUpdateCampaignDetails({

--- a/frontend-nextjs/src/components/application-answer/role-card.tsx
+++ b/frontend-nextjs/src/components/application-answer/role-card.tsx
@@ -1,4 +1,4 @@
-import { DraggableProvided} from "@hello-pangea/dnd";
+import { DraggableProvided } from "@hello-pangea/dnd";
 import { GripVertical } from "lucide-react"
 import { RoleDetails } from "@/models/campaign";
 import { Info } from "lucide-react";
@@ -45,7 +45,7 @@ export function RoleCard({
               <span className="inline-flex items-center justify-center w-5 h-5 text-xs font-semibold bg-primary text-primary-foreground rounded-full">
                 {index! + 1}
               </span>
-            ) : <GripVertical/>}
+            ) : <GripVertical />}
           </div>
           <h3 className="font-medium text-sm truncate">{role.name}</h3>
         </div>
@@ -56,18 +56,17 @@ export function RoleCard({
               <TooltipTrigger asChild>
                 <Info className="h-4 w-4 text-primary" />
               </TooltipTrigger>
-              <TooltipContent side="top">
+              <TooltipContent side="top" className="max-w-xs">
                 {role.description}
               </TooltipContent>
             </Tooltip>
           )}
 
           <span
-            className={`text-xs px-2 py-1 rounded-full ${
-              selected
-                ? "bg-accent text-accent-foreground"
-                : "bg-muted text-muted-foreground"
-            }`}
+            className={`text-xs px-2 py-1 rounded-full ${selected
+              ? "bg-accent text-accent-foreground"
+              : "bg-muted text-muted-foreground"
+              }`}
           >
             {selected ? dict.common.selected : dict.common.select}
           </span>

--- a/frontend-nextjs/src/lib/utils.ts
+++ b/frontend-nextjs/src/lib/utils.ts
@@ -69,8 +69,3 @@ export function privateStatusLabel(status: ApplicationStatus): string {
       return "Interview";
   }
 }
-
-export function getWordCount (text: string) {
-  if (!text) return 0;
-  return text.trim().split(/\s+/).length;
-};

--- a/frontend-nextjs/src/lib/utils.ts
+++ b/frontend-nextjs/src/lib/utils.ts
@@ -69,3 +69,8 @@ export function privateStatusLabel(status: ApplicationStatus): string {
       return "Interview";
   }
 }
+
+export function getWordCount (text: string) {
+  if (!text) return 0;
+  return text.trim().split(/\s+/).length;
+};


### PR DESCRIPTION
- Info icon is already fixed before the PR. If role name is too long, it gets truncated into ellipsis.
- Add char count limit for description. Campaign details edit won't be updated if description exceeds limit. [Note: lowkey, low UX since they are unaware it will be unsaved despite the toast error?]