### PR TITLE
Chaos 805 unselecting behaviour and preference percentage

### DIFF
--- a/backend/api.json
+++ b/backend/api.json
@@ -2773,10 +2773,10 @@
             "type": "String",
             "example": "Sponsorships"
           },
-          "preference": {
+          "preference_percentage": {
             "type": "integer",
             "format": "int32",
-            "example": 1
+            "example": 50
           }
         }
       },

--- a/backend/api.yaml
+++ b/backend/api.yaml
@@ -2673,10 +2673,11 @@ components:
         campaign_role_id:
           type: string
           example: "6996987893965227485"
-        preference:
+        preference_percentage:
           type: integer
           format: int32
-          example: 1
+          description: Percentage preference for this role. The sum across an application's roles must equal 100 when submitted.
+          example: 50
 
     NewAnswer:
       type: object

--- a/backend/database-seeding/src/seeder.rs
+++ b/backend/database-seeding/src/seeder.rs
@@ -377,7 +377,7 @@ pub async fn seed_database(dev_email: String, mut seeder: Seeder) {
             applied_roles: vec![ApplicationRole {
                 application_id: 0,
                 campaign_role_id: role_id_1,
-                preference: 1,
+                preference_percentage: 100,
             }],
         },
         &mut seeder.app_state.snowflake_generator,
@@ -393,7 +393,7 @@ pub async fn seed_database(dev_email: String, mut seeder: Seeder) {
             applied_roles: vec![ApplicationRole {
                 application_id: 0,
                 campaign_role_id: role_id_2,
-                preference: 1,
+                preference_percentage: 100,
             }],
         },
         &mut seeder.app_state.snowflake_generator,

--- a/backend/migrations/20260721120000_application_roles_preference_percentage.sql
+++ b/backend/migrations/20260721120000_application_roles_preference_percentage.sql
@@ -1,0 +1,24 @@
+ALTER TABLE application_roles RENAME COLUMN preference TO preference_percentage;
+
+CREATE OR REPLACE FUNCTION check_application_roles_percentage_sum()
+RETURNS TRIGGER AS $$
+DECLARE
+    total INTEGER;
+BEGIN
+    IF NEW.submitted IS TRUE AND OLD.submitted IS NOT TRUE THEN
+        SELECT COALESCE(SUM(preference_percentage), 0) INTO total
+        FROM application_roles
+        WHERE application_id = NEW.id;
+
+        IF total <> 100 THEN
+            RAISE EXCEPTION 'application % role preference_percentage must sum to 100, got %', NEW.id, total;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_check_application_roles_percentage_sum
+AFTER UPDATE OF submitted ON applications
+FOR EACH ROW
+EXECUTE FUNCTION check_application_roles_percentage_sum();

--- a/backend/server/src/handler/application.rs
+++ b/backend/server/src/handler/application.rs
@@ -205,7 +205,7 @@ impl ApplicationHandler {
     /// Retrieves all roles associated with a specific application.
     ///
     /// This handler allows application owners to view all roles they have applied for
-    /// in a specific application, including their preference rankings.
+    /// in a specific application, including their preference percentages.
     ///
     /// # Arguments
     ///

--- a/backend/server/src/models/application.rs
+++ b/backend/server/src/models/application.rs
@@ -63,8 +63,9 @@ pub struct ApplicationRole {
     #[serde(serialize_with = "crate::models::serde_string::serialize")]
     #[serde(deserialize_with = "crate::models::serde_string::deserialize")]
     pub campaign_role_id: i64,
-    /// User's preference ranking for this role (lower number = higher preference)
-    pub preference: i32,
+    /// User's preference for this role, as a percentage. The sum across all of an
+    /// application's roles must equal 100 by the time the application is submitted.
+    pub preference_percentage: i32,
 }
 
 /// Data structure for creating a new application.
@@ -76,8 +77,9 @@ pub struct UpdateRoleEntry {
     #[serde(serialize_with = "crate::models::serde_string::serialize")]
     #[serde(deserialize_with = "crate::models::serde_string::deserialize")]
     pub campaign_role_id: i64,
-    /// User's preference ranking for this role (lower number = higher preference)
-    pub preference: i32,
+    /// User's preference for this role, as a percentage. The sum across all of an
+    /// application's roles must equal 100 by the time the application is submitted.
+    pub preference_percentage: i32,
 }
 
 /// Data structure for creating a new application.
@@ -160,8 +162,8 @@ pub struct ApplicationAppliedRoleDetails {
     pub campaign_role_id: i64,
     /// Name of the role
     pub role_name: String,
-    /// User's preference ranking for this role
-    pub preference: i32,
+    /// User's preference for this role, as a percentage
+    pub preference_percentage: i32,
 }
 
 /// Data structure for updating role preferences in an application.
@@ -346,12 +348,12 @@ impl Application {
         for role_applied in application_data.applied_roles {
             sqlx::query!(
                 "
-                    INSERT INTO application_roles (application_id, campaign_role_id, preference)
+                    INSERT INTO application_roles (application_id, campaign_role_id, preference_percentage)
                     VALUES ($1, $2, $3)
                 ",
                 id,
                 role_applied.campaign_role_id,
-                role_applied.preference
+                role_applied.preference_percentage
             )
             .execute(transaction.deref_mut())
             .await?;
@@ -400,7 +402,7 @@ impl Application {
             ApplicationAppliedRoleDetails,
             "
                 SELECT application_roles.campaign_role_id,
-                application_roles.preference, campaign_roles.name AS role_name
+                application_roles.preference_percentage, campaign_roles.name AS role_name
                 FROM application_roles
                     JOIN campaign_roles
                     ON application_roles.campaign_role_id = campaign_roles.id
@@ -478,7 +480,7 @@ impl Application {
             ApplicationAppliedRoleDetails,
             "
                 SELECT application_roles.campaign_role_id,
-                application_roles.preference, campaign_roles.name AS role_name
+                application_roles.preference_percentage, campaign_roles.name AS role_name
                 FROM application_roles
                     JOIN campaign_roles
                     ON application_roles.campaign_role_id = campaign_roles.id
@@ -553,7 +555,7 @@ impl Application {
                 ApplicationAppliedRoleDetails,
                 "
                     SELECT application_roles.campaign_role_id,
-                    application_roles.preference, campaign_roles.name AS role_name
+                    application_roles.preference_percentage, campaign_roles.name AS role_name
                     FROM application_roles
                         JOIN campaign_roles
                         ON application_roles.campaign_role_id = campaign_roles.id
@@ -633,7 +635,7 @@ impl Application {
                 ApplicationAppliedRoleDetails,
                 "
                     SELECT application_roles.campaign_role_id,
-                    application_roles.preference, campaign_roles.name AS role_name
+                    application_roles.preference_percentage, campaign_roles.name AS role_name
                     FROM application_roles
                         JOIN campaign_roles
                         ON application_roles.campaign_role_id = campaign_roles.id
@@ -772,7 +774,7 @@ impl Application {
                 ApplicationAppliedRoleDetails,
                 "
                     SELECT application_roles.campaign_role_id,
-                    application_roles.preference, campaign_roles.name AS role_name
+                    application_roles.preference_percentage, campaign_roles.name AS role_name
                     FROM application_roles
                         JOIN campaign_roles
                         ON application_roles.campaign_role_id = campaign_roles.id
@@ -875,8 +877,8 @@ impl Application {
     /// Retrieves all roles associated with a specific application.
     ///
     /// This function queries the database to get all application roles for a given
-    /// application ID, including their preference rankings. The roles are returned
-    /// in the order they appear in the database (typically by preference).
+    /// application ID, including their preference percentages. The roles are returned
+    /// most-preferred first.
     ///
     /// # Arguments
     ///
@@ -893,10 +895,10 @@ impl Application {
         let roles = sqlx::query_as!(
             ApplicationRole,
             "
-                SELECT application_id, campaign_role_id, preference
+                SELECT application_id, campaign_role_id, preference_percentage
                 FROM application_roles
                 WHERE application_id = $1
-                ORDER BY preference
+                ORDER BY preference_percentage DESC
             ",
             id
         )
@@ -935,12 +937,12 @@ impl Application {
         for role in roles {
             sqlx::query!(
                 "
-                    INSERT INTO application_roles (application_id, campaign_role_id, preference)
+                    INSERT INTO application_roles (application_id, campaign_role_id, preference_percentage)
                     VALUES ($1, $2, $3)
                 ",
                 id,
                 role.campaign_role_id,
-                role.preference
+                role.preference_percentage
             )
             .execute(transaction.deref_mut())
             .await?;
@@ -950,6 +952,10 @@ impl Application {
     }
 
     /// Submits an application, marking it as ready for review.
+    ///
+    /// Role preference percentages must sum to 100 across the application's roles;
+    /// this is checked here (for a clean error message) and enforced in the database
+    /// by a trigger on this column (defense in depth against any other write path).
     ///
     /// # Arguments
     ///
@@ -963,6 +969,25 @@ impl Application {
         id: i64,
         transaction: &mut Transaction<'_, Postgres>,
     ) -> Result<(), ChaosError> {
+        let total_percentage = sqlx::query!(
+            "
+                SELECT COALESCE(SUM(preference_percentage), 0) AS total
+                FROM application_roles
+                WHERE application_id = $1
+            ",
+            id
+        )
+        .fetch_one(transaction.deref_mut())
+        .await?
+        .total
+        .unwrap_or(0);
+
+        if total_percentage != 100 {
+            return Err(ChaosError::BadRequestWithMessage(
+                "Role preferences must add up to 100%".to_string(),
+            ));
+        }
+
         sqlx::query!(
             "
                 UPDATE applications SET submitted = true WHERE id = $1 RETURNING id

--- a/frontend-nextjs/src/app/[lang]/campaign/apply/[campaignId]/application/[applicationId]/application-answer.tsx
+++ b/frontend-nextjs/src/app/[lang]/campaign/apply/[campaignId]/application/[applicationId]/application-answer.tsx
@@ -55,6 +55,7 @@ export default function ApplicationReview({
   });
 
   const [selectedRoleIds, setSelectedRoleIds] = useState<string[]>([]);
+  const [rolePercentages, setRolePercentages] = useState<Record<string, number>>({});
   const [activeTab, setActiveTab] = useState<"general" | string>("general");
   const [qaByRole, setQAByRole] = useState<Map<string, QuestionAndAnswer[]>>(new Map());
   const queryClient = useQueryClient()
@@ -130,37 +131,37 @@ export default function ApplicationReview({
     });
   };
 
+  // even split across n roles that always sums to exactly 100 (remainder on the last role)
+  const evenSplit = (n: number): number[] => {
+    if (n === 0) return [];
+    const base = Math.floor(100 / n);
+    const splits = Array(n).fill(base);
+    splits[n - 1] += 100 - base * n;
+    return splits;
+  };
+
   // format roles to match what backend expects
-  const buildUpdatedRolesPayload = (orderedIds: string[]) => {
-    if (!application?.applied_roles || application.applied_roles.length === 0) {
-      return orderedIds.map((campaignRoleId, index) => ({
-        campaign_role_id: campaignRoleId,
-        preference: index
-      }));
-    }
-
-    return orderedIds.map((campaignRoleId, index) => {
-      const existing = application.applied_roles.find(
-        r => String(r.campaign_role_id) === String(campaignRoleId)
-      );
-
-      if (!existing) {
-        return {
-          campaign_role_id: campaignRoleId,
-          preference: index
-        };
-      }
-
-      return {
-        campaign_role_id: existing.campaign_role_id,
-        preference: index
-      };
-    });
+  const buildUpdatedRolesPayload = (orderedIds: string[], percentages: Record<string, number>) => {
+    return orderedIds.map((campaignRoleId) => ({
+      campaign_role_id: campaignRoleId,
+      preference_percentage: percentages[campaignRoleId] ?? 0,
+    }));
   };
 
   // update roles in backend
   const updateRoles = async (nextSelectedRoles: string[]) => {
+    const lengthChanged = nextSelectedRoles.length !== selectedRoleIds.length;
+    const nextPercentages = lengthChanged
+      ? Object.fromEntries(
+          nextSelectedRoles.map((id, i) => [id, evenSplit(nextSelectedRoles.length)[i]])
+        )
+      : rolePercentages;
+
     setSelectedRoleIds(nextSelectedRoles)
+    if (lengthChanged) setRolePercentages(nextPercentages);
+    if (activeTab !== "general" && !nextSelectedRoles.includes(activeTab)) {
+      setActiveTab("general");
+    }
     setQAByRole(prev => {
       const newQAMap = new Map<string, QuestionAndAnswer[]>();
       if (prev.has('general')) {
@@ -209,21 +210,34 @@ export default function ApplicationReview({
     });
 
     try {
-      const payload = {
-        roles: buildUpdatedRolesPayload(nextSelectedRoles),
-      };
-      await updateApplicationRoles(applicationId, payload.roles);
+      const payload = buildUpdatedRolesPayload(nextSelectedRoles, nextPercentages);
+      await updateApplicationRoles(applicationId, payload);
     } catch (err) {
       console.error("Failed to update roles:", err);
     }
   }
 
+  // update a single role's percentage (does not change selection or order)
+  const handlePercentageChange = async (campaignRoleId: string, value: number) => {
+    const nextPercentages = { ...rolePercentages, [campaignRoleId]: value };
+    setRolePercentages(nextPercentages);
+
+    try {
+      const payload = buildUpdatedRolesPayload(selectedRoleIds, nextPercentages);
+      await updateApplicationRoles(applicationId, payload);
+    } catch (err) {
+      console.error("Failed to update role preference:", err);
+    }
+  };
+
   useEffect(() => {
     if (application?.applied_roles) {
-      setSelectedRoleIds(
-        [...application.applied_roles]
-          .sort((a, b) => a.preference - b.preference)
-          .map(r => String(r.campaign_role_id))
+      const sorted = [...application.applied_roles].sort(
+        (a, b) => b.preference_percentage - a.preference_percentage
+      );
+      setSelectedRoleIds(sorted.map(r => String(r.campaign_role_id)));
+      setRolePercentages(
+        Object.fromEntries(sorted.map(r => [String(r.campaign_role_id), r.preference_percentage]))
       );
     }
   }, [application]);
@@ -233,9 +247,9 @@ export default function ApplicationReview({
       await submitApplication(applicationId)
       queryClient.invalidateQueries({ queryKey: [`application-${applicationId}`] });
       router.push(`/campaign/apply/${campaignId}/finish`);
-    } catch (e) {
+    } catch (e: any) {
       console.error("Submission failed: ", e);
-      toast.error("Failed to submit application. Please try again.");
+      toast.error(e?.message || "Failed to submit application. Please try again.");
     }
   }
 
@@ -267,7 +281,7 @@ export default function ApplicationReview({
         <div></div>
         <div className="flex w-full flex-col gap-4 lg:gap-8 xl:flex-row">
           <div className="w-full xl:w-80 xl:shrink-0">
-            <RoleSelector roles={roles} maxRolesPerApplication={campaign?.max_roles_per_application} selectedRoleIds={selectedRoleIds} onChangeSelectedRoles={updateRoles} applicationId={applicationId} dict={dict} />
+            <RoleSelector roles={roles} maxRolesPerApplication={campaign?.max_roles_per_application} selectedRoleIds={selectedRoleIds} onChangeSelectedRoles={updateRoles} rolePercentages={rolePercentages} onChangeRolePercentage={handlePercentageChange} applicationId={applicationId} dict={dict} />
           </div>
           <div className="min-w-0 flex-1">
             <div className="overflow-x-auto pb-1">
@@ -277,7 +291,7 @@ export default function ApplicationReview({
               <MainContent campaignId={campaignId} applicationId={applicationId} activeTab={activeTab} dict={dict} updateRoleAnswers={updateQuestionAnswer} qaByRole={qaByRole} />
               <TabSwitcher roles={roles} selectedRoleIds={selectedRoleIds} activeTab={activeTab} onChangeActiveTab={setActiveTab} dict={dict} />
             </div>
-            <ReviewCard questionsAndAnswersByRole={qaByRole} selectedRoleIds={selectedRoleIds} roles={roles} applicationId={applicationId} handleSubmit={handleApplicationSubmit} dict={dict} />
+            <ReviewCard questionsAndAnswersByRole={qaByRole} selectedRoleIds={selectedRoleIds} rolePercentages={rolePercentages} roles={roles} applicationId={applicationId} handleSubmit={handleApplicationSubmit} dict={dict} />
           </div>
         </div>
       </div>

--- a/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/review/components/application-panel.tsx
+++ b/frontend-nextjs/src/app/[lang]/dashboard/organisation/[orgId]/campaigns/[campaignId]/review/components/application-panel.tsx
@@ -7,10 +7,7 @@ import {
   getApplicationRoleStatuses,
 } from "@/models/application";
 import { getCategoryRatingsByApplication } from "@/models/rating";
-import {
-  getUnreadCommentCount,
-  markAllCommentsRead,
-} from "@/models/comment";
+import { getUnreadCommentCount, markAllCommentsRead } from "@/models/comment";
 import { useState, useMemo } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Button } from "@/components/ui/button";
@@ -33,7 +30,7 @@ import {
   DrawerContent,
   DrawerHeader,
   DrawerTitle,
-} from "@/components/ui/drawer"
+} from "@/components/ui/drawer";
 
 export function ApplicationPanel({
   app,
@@ -52,13 +49,24 @@ export function ApplicationPanel({
   dict: any;
   ratedApplications: Record<string, boolean>;
   setRatedApplications: (v: Record<string, boolean>) => void;
-  onDecision: (appId: string, roleId: string, status: ApplicationStatus) => void;
+  onDecision: (
+    appId: string,
+    roleId: string,
+    status: ApplicationStatus,
+  ) => void;
 }) {
-  const [activeTab, setActiveTab] = useState<"application" | "review">("application");
+  const [activeTab, setActiveTab] = useState<"application" | "review">(
+    "application",
+  );
   const [discussionOpen, setDiscussionOpen] = useState(false);
-  const sortedRoles = [...app.applied_roles].sort((a, b) => a.preference - b.preference);
+  const sortedRoles = [...app.applied_roles].sort(
+    (a, b) => b.preference_percentage - a.preference_percentage,
+  );
   const [selectedRoleId, setSelectedRoleId] = useState<string | null>(
     sortedRoles[0]?.campaign_role_id ?? null,
+  );
+  const selectedRole = sortedRoles.find(
+    (r) => r.campaign_role_id === selectedRoleId,
   );
 
   const { data: allRatings } = useQuery({
@@ -96,7 +104,9 @@ export function ApplicationPanel({
   const avgRating = useMemo(() => {
     if (!allRatings || allRatings.length === 0) return 0;
     const values = allRatings.flatMap((r) =>
-      r.category_ratings.filter((cr) => cr.rating !== null).map((cr) => cr.rating as number),
+      r.category_ratings
+        .filter((cr) => cr.rating !== null)
+        .map((cr) => cr.rating as number),
     );
     if (values.length === 0) return 0;
     return Math.round(values.reduce((sum, v) => sum + v, 0) / values.length);
@@ -118,11 +128,16 @@ export function ApplicationPanel({
             </div>
             <Select
               value={
-                roleStatuses?.find((rs) => rs.campaign_role_id === selectedRoleId)?.status ??
-                "Pending"
+                roleStatuses?.find(
+                  (rs) => rs.campaign_role_id === selectedRoleId,
+                )?.status ?? "Pending"
               }
               onValueChange={(v) =>
-                onDecision(app.id, selectedRoleId as string, v as ApplicationStatus)
+                onDecision(
+                  app.id,
+                  selectedRoleId as string,
+                  v as ApplicationStatus,
+                )
               }
             >
               <SelectTrigger className="h-8 w-32 text-sm">
@@ -138,25 +153,49 @@ export function ApplicationPanel({
           </div>
         </div>
 
-        {/* Role chips */}
-        <div className="flex items-center gap-3 mt-3 pb-3 flex-wrap">
-          {sortedRoles.map((role, i) => (
-            <div key={role.campaign_role_id} className="flex items-center gap-1">
-              <span className="text-xs text-muted-foreground">{i + 1}.</span>
-              <button
-                type="button"
-                onClick={() => setSelectedRoleId(role.campaign_role_id)}
-                className={cn(
-                  "px-3 py-0.5 rounded-full text-sm font-medium transition-colors",
-                  selectedRoleId === role.campaign_role_id
-                    ? "bg-primary text-primary-foreground"
-                    : "border border-border hover:bg-muted",
-                )}
+        {/* Role chips + preference bar */}
+        <div className="flex items-center justify-between gap-4 mt-3 pb-3">
+          <div className="flex items-center gap-3 flex-wrap">
+            {sortedRoles.map((role, i) => (
+              <div
+                key={role.campaign_role_id}
+                className="flex items-center gap-1"
               >
-                {role.role_name}
-              </button>
+                <span className="text-xs text-muted-foreground">{i + 1}.</span>
+                <button
+                  type="button"
+                  onClick={() => setSelectedRoleId(role.campaign_role_id)}
+                  className={cn(
+                    "px-3 py-0.5 rounded-full text-sm font-medium transition-colors",
+                    selectedRoleId === role.campaign_role_id
+                      ? "bg-primary text-primary-foreground"
+                      : "border border-border hover:bg-muted",
+                  )}
+                >
+                  {role.role_name}
+                </button>
+              </div>
+            ))}
+          </div>
+          {selectedRole && (
+            <div className="relative h-7 w-96 shrink-0 overflow-hidden rounded-full border border-primary/40">
+              <div
+                className="absolute inset-y-0 left-0 rounded-full bg-primary transition-[width]"
+                style={{ width: `${selectedRole.preference_percentage}%` }}
+              />
+              <span className="absolute inset-y-0 left-3 flex items-center whitespace-nowrap text-[10px] font-medium text-primary">
+                preference {selectedRole.preference_percentage}%
+              </span>
+              <div
+                className="absolute inset-y-0 left-0 overflow-hidden transition-[width]"
+                style={{ width: `${selectedRole.preference_percentage}%` }}
+              >
+                <span className="absolute inset-y-0 left-3 flex items-center whitespace-nowrap text-[10px] font-medium text-primary-foreground">
+                  preference {selectedRole.preference_percentage}%
+                </span>
+              </div>
             </div>
-          ))}
+          )}
         </div>
       </div>
       {/* Tab bar */}
@@ -225,15 +264,15 @@ export function ApplicationPanel({
         )}
       </div>
 
-
-      <Drawer direction="right" open={discussionOpen} onOpenChange={handleDiscussionOpenChange}>
-        <DrawerContent
-          className="sm:max-w-lg"
-        >
+      <Drawer
+        direction="right"
+        open={discussionOpen}
+        onOpenChange={handleDiscussionOpenChange}
+      >
+        <DrawerContent className="sm:max-w-lg">
           <DrawerHeader className="flex flex-row items-center justify-between px-4 border-b">
             <DrawerTitle>Discussion</DrawerTitle>
-            <DrawerClose className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-            >
+            <DrawerClose className="p-1 rounded hover:bg-muted text-muted-foreground hover:text-foreground transition-colors">
               <X className="w-4 h-4" />
             </DrawerClose>
           </DrawerHeader>

--- a/frontend-nextjs/src/components/application-answer/review-card.tsx
+++ b/frontend-nextjs/src/components/application-answer/review-card.tsx
@@ -1,249 +1,268 @@
 import { QuestionAndAnswer } from "@/models/question";
-import { Button } from "@/components/ui/button"
+import { Button } from "@/components/ui/button";
 import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogHeader,
-    DialogTitle,
-} from "@/components/ui/dialog"
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { useState } from "react";
 import { CampaignRole, RoleDetails } from "@/models/campaign";
 import { Tooltip, TooltipProvider, TooltipContent, TooltipTrigger } from "../ui/tooltip";
+import RolePercentageBar from "./role-percentage-bar";
 export default function ReviewCard({
-    questionsAndAnswersByRole,
-    applicationId,
-    selectedRoleIds,
-    handleSubmit,
-    roles,
-    dict
+  questionsAndAnswersByRole,
+  applicationId,
+  selectedRoleIds,
+  rolePercentages,
+  handleSubmit,
+  roles,
+  dict,
 }: {
-    questionsAndAnswersByRole: Map<string, QuestionAndAnswer[]>;
-    applicationId: string;
-    selectedRoleIds: string[];
-    handleSubmit: () => void;
-    roles: RoleDetails[] | undefined;
-    dict: any;
+  questionsAndAnswersByRole: Map<string, QuestionAndAnswer[]>;
+  applicationId: string;
+  selectedRoleIds: string[];
+  rolePercentages: Record<string, number>;
+  handleSubmit: () => void;
+  roles: RoleDetails[] | undefined;
+  dict: any;
 }) {
-    const [open, setOpen] = useState(false)
+  const [open, setOpen] = useState(false);
 
-    // vibed this
-    const requiredUnanswered = Array.from(
-        questionsAndAnswersByRole.values()
-    )
-        .flat()
-        .some((qa) => {
-            if (!qa) return false;
-            if (!qa.required) return false;
+  const totalPercentage = selectedRoleIds.reduce(
+    (sum, id) => sum + (rolePercentages[id] ?? 0),
+    0,
+  );
+  const percentageInvalid =
+    selectedRoleIds.length > 0 && totalPercentage !== 100;
 
-            if (qa.answer == null) return true;
-            if (qa.answer === "No Answer") return true;
-            if (qa.answer === "__NO_ANSWER__") return true;
+  // vibed this
+  const requiredUnanswered = Array.from(questionsAndAnswersByRole.values())
+    .flat()
+    .some((qa) => {
+      if (!qa) return false;
+      if (!qa.required) return false;
 
-            if (typeof qa.answer === "string") {
-                return qa.answer.trim() === "";
-            }
+      if (qa.answer == null) return true;
+      if (qa.answer === "No Answer") return true;
+      if (qa.answer === "__NO_ANSWER__") return true;
 
-            if (Array.isArray(qa.answer)) {
-                return qa.answer.length === 0;
-            }
+      if (typeof qa.answer === "string") {
+        return qa.answer.trim() === "";
+      }
 
-            return false;
-        });
+      if (Array.isArray(qa.answer)) {
+        return qa.answer.length === 0;
+      }
 
-    function renderAnswerPreview(qa: QuestionAndAnswer): string {
-        if (!qa.answer || qa.answer === "__NO_ANSWER__") {
-            return "No answer";
-        }
+      return false;
+    });
 
-        switch (qa.question_type) {
-            case "ShortAnswer":
-                return String(qa.answer);
-
-            case "DropDown":
-            case "MultiChoice": {
-                const option = qa.options.find(o => o.id === qa.answer);
-                return option ? option.text : String(qa.answer);
-            }
-
-            case "MultiSelect":
-                //ts so cooked, it expects string from backend but frontend needs conversions ;-;
-                if (typeof qa.answer === "string") {
-                    return qa.answer === "No Answer" ? "No Answer" : qa.answer;
-                }
-                if (!Array.isArray(qa.answer) || qa.answer.length === 0) {
-                    return "No Answer";
-                }
-                return qa.answer
-                    .map(id => {
-                        const opt = qa.options.find(o => o.id === id);
-                        return opt ? opt.text : String(id);
-                    })
-                    .join(", ");
-
-            case "Ranking":
-                // Unanswered ranking is the string "No Answer" from processAnswerForDisplay
-                if (
-                    !qa.answer ||
-                    qa.answer === "No Answer" ||
-                    qa.answer === "__NO_ANSWER__"
-                ) {
-                    return "No Answer";
-                }
-                // vibed this too cause lowk didn't know how to map it in the best way
-                // Backend always returns rankings in string form, so we have to split it up to render nicely
-                if (qa.answer === "No Answer") {
-                    return "No Answer";
-                }
-
-                if (
-                    typeof qa.answer === "string" &&
-                    /^\s*\d+\.\s+/.test(qa.answer)
-                ) {
-                    return qa.answer;
-                }
-
-                let ids: string[] = [];
-                if (Array.isArray(qa.answer)) {
-                    ids = qa.answer.map(String);
-                } else if (typeof qa.answer === "string") {
-                    ids = qa.answer
-                        .replace(/^\[|\]$/g, "")
-                        .split(",")
-                        .map(s => s.trim())
-                        .filter(Boolean);
-                }
-
-                const ranked = ids.map((id, index) => {
-                    const option = qa.options.find(o => String(o.id) === id);
-                    const text = option?.text ?? id;
-                    return `${index + 1}. ${text}`;
-                });
-
-                return ranked.join(", ");
-
-            default:
-                return String(qa.answer);
-        }
+  function renderAnswerPreview(qa: QuestionAndAnswer): string {
+    if (!qa.answer || qa.answer === "__NO_ANSWER__") {
+      return "No answer";
     }
 
-    return (
-        <>
-            <button
-                type="button"
-                onClick={() => setOpen(true)}
-                className="fixed bottom-4 left-4 right-4 z-50 inline-flex items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 text-center text-sm font-semibold text-primary-foreground shadow-[0_10px_30px_-12px_hsl(var(--primary))] transition-all hover:-translate-y-0.5 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0 active:brightness-100 sm:bottom-6 sm:left-auto sm:right-6 sm:w-auto sm:px-5"
-            >
-                {dict.applicationpage.submit_answers}
-            </button>
-            <Dialog open={open} onOpenChange={setOpen}>
-                <DialogContent className="flex max-h-[85vh] w-[95vw] max-w-3xl flex-col overflow-y-auto sm:w-[92vw]">
-                    <div className="sticky top-0 z-10 bg-background">
-                        <DialogHeader>
-                            <DialogTitle>
-                                {dict.applicationpage.review_answers}
-                            </DialogTitle>
-                            <DialogDescription>
-                                {dict.applicationpage.review_answers_desc}
-                            </DialogDescription>
-                        </DialogHeader>
-                    </div>
-                    <div className="flex-1 overflow-y-auto px-1 pb-4 pt-4 sm:px-2 sm:pb-6">
-                        {questionsAndAnswersByRole.has('general') && (
-                            (() => {
-                                const qas = questionsAndAnswersByRole.get('general');
-                                const role = roles?.find(r => String(r.id) === String('general'));
-                                return (
-                                    <div key="general" className="mb-6">
-                                        <h3 className="text-lg font-bold sm:text-xl">
-                                            General
-                                        </h3>
-                                        {!qas || qas.length === 0 ? (
-                                            <p>General has no questions</p>
-                                        ) : (
-                                            qas.map(qa => {
-                                                const answer = renderAnswerPreview(qa)
-                                                return (
-                                                    <div key={qa.question_id} className="mb-2">
-                                                        <div className="flex items-start gap-1">
-                                                            <h4 className="text-sm font-semibold sm:text-base">{qa.text}</h4>
-                                                            {qa.required && (
-                                                                <div className="text-destructive font-bold">*</div>
-                                                            )}
-                                                        </div>
-                                                        <div className="mt-2 overflow-x-auto rounded bg-muted p-3 text-sm">
-                                                            {answer}
-                                                        </div>
-                                                    </div>
-                                                )
-                                            })
-                                        )}
-                                    </div>
-                                );
-                            })()
-                        )}
+    switch (qa.question_type) {
+      case "ShortAnswer":
+        return String(qa.answer);
 
-                        {selectedRoleIds.map(roleId => {
-                            if (roleId === 'general') return null;
+      case "DropDown":
+      case "MultiChoice": {
+        const option = qa.options.find((o) => o.id === qa.answer);
+        return option ? option.text : String(qa.answer);
+      }
 
-                            const qas = questionsAndAnswersByRole.get(roleId);
-                            const role = roles?.find(r => String(r.id) === String(roleId));
+      case "MultiSelect":
+        //ts so cooked, it expects string from backend but frontend needs conversions ;-;
+        if (typeof qa.answer === "string") {
+          return qa.answer === "No Answer" ? "No Answer" : qa.answer;
+        }
+        if (!Array.isArray(qa.answer) || qa.answer.length === 0) {
+          return "No Answer";
+        }
+        return qa.answer
+          .map((id) => {
+            const opt = qa.options.find((o) => o.id === id);
+            return opt ? opt.text : String(id);
+          })
+          .join(", ");
 
-                            return (
-                                <div key={roleId} className="mb-6">
-                                    <h3 className="text-lg font-bold sm:text-xl">
-                                        {role?.name ?? `Role ${roleId}`}
-                                    </h3>
-                                    {!qas || qas.length === 0 ? (
-                                        <p>This role has no questions</p>
-                                    ) : (
-                                        qas.map(qa => {
-                                            const answer = renderAnswerPreview(qa)
-                                            return (
-                                                <div key={qa.question_id} className="mb-2">
-                                                    <div className="flex items-start gap-1">
-                                                        <h4 className="text-sm font-semibold sm:text-base">{qa.text}</h4>
-                                                        {qa.required && (
-                                                            <div className="text-destructive font-bold">*</div>
-                                                        )}
-                                                    </div>
-                                                    <div className="mt-2 overflow-x-auto rounded bg-muted p-3 text-sm">
-                                                        {answer}
-                                                    </div>
-                                                </div>
-                                            )
-                                        })
-                                    )}
+      case "Ranking":
+        // Unanswered ranking is the string "No Answer" from processAnswerForDisplay
+        if (
+          !qa.answer ||
+          qa.answer === "No Answer" ||
+          qa.answer === "__NO_ANSWER__"
+        ) {
+          return "No Answer";
+        }
+        // vibed this too cause lowk didn't know how to map it in the best way
+        // Backend always returns rankings in string form, so we have to split it up to render nicely
+        if (qa.answer === "No Answer") {
+          return "No Answer";
+        }
+
+        if (typeof qa.answer === "string" && /^\s*\d+\.\s+/.test(qa.answer)) {
+          return qa.answer;
+        }
+
+        let ids: string[] = [];
+        if (Array.isArray(qa.answer)) {
+          ids = qa.answer.map(String);
+        } else if (typeof qa.answer === "string") {
+          ids = qa.answer
+            .replace(/^\[|\]$/g, "")
+            .split(",")
+            .map((s) => s.trim())
+            .filter(Boolean);
+        }
+
+        const ranked = ids.map((id, index) => {
+          const option = qa.options.find((o) => String(o.id) === id);
+          const text = option?.text ?? id;
+          return `${index + 1}. ${text}`;
+        });
+
+        return ranked.join(", ");
+
+      default:
+        return String(qa.answer);
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 left-4 right-4 z-50 inline-flex items-center justify-center gap-2 rounded-xl bg-primary px-4 py-3 text-center text-sm font-semibold text-primary-foreground shadow-[0_10px_30px_-12px_hsl(var(--primary))] transition-all hover:-translate-y-0.5 hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 active:translate-y-0 active:brightness-100 sm:bottom-6 sm:left-auto sm:right-6 sm:w-auto sm:px-5"
+      >
+        {dict.applicationpage.submit_answers}
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="flex max-h-[85vh] w-[95vw] max-w-3xl flex-col overflow-y-auto sm:w-[92vw]">
+          <div className="sticky top-0 z-10 bg-background">
+            <DialogHeader>
+              <DialogTitle>{dict.applicationpage.review_answers}</DialogTitle>
+              <DialogDescription>
+                {dict.applicationpage.review_answers_desc}
+              </DialogDescription>
+            </DialogHeader>
+          </div>
+          <div className="flex-1 overflow-y-auto px-1 pb-4 pt-4 sm:px-2 sm:pb-6">
+            <RolePercentageBar
+              selectedRoleIds={selectedRoleIds}
+              rolePercentages={rolePercentages}
+              roles={roles}
+              totalPercentage={totalPercentage}
+              percentageInvalid={percentageInvalid}
+              dict={dict}
+            />
+
+            {questionsAndAnswersByRole.has("general") &&
+              (() => {
+                const qas = questionsAndAnswersByRole.get("general");
+                const role = roles?.find(
+                  (r) => String(r.id) === String("general"),
+                );
+                return (
+                  <div key="general" className="mb-6">
+                    <h3 className="text-lg font-bold sm:text-xl">General</h3>
+                    {!qas || qas.length === 0 ? (
+                      <p>General has no questions</p>
+                    ) : (
+                      qas.map((qa) => {
+                        const answer = renderAnswerPreview(qa);
+                        return (
+                          <div key={qa.question_id} className="mb-2">
+                            <div className="flex items-start gap-1">
+                              <h4 className="text-sm font-semibold sm:text-base">
+                                {qa.text}
+                              </h4>
+                              {qa.required && (
+                                <div className="text-destructive font-bold">
+                                  *
                                 </div>
-                            );
-                        })}
-                    </div>
-                    <div className="sticky bottom-0 z-10 border-t bg-background p-4">
-                        <TooltipProvider>
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <span className="inline-block w-full">
-                                        <Button
-                                            className="w-full rounded-lg border border-primary bg-primary text-primary-foreground transition-all hover:-translate-y-0.5 hover:brightness-110 active:translate-y-0 active:brightness-100 disabled:opacity-50 disabled:cursor-not-allowed"
-                                            type="button"
-                                            disabled={requiredUnanswered}
-                                            onClick={() => handleSubmit()}
-                                        >
-                                            {dict.applicationpage.submit_application}
-                                        </Button>
-                                    </span>
-                                </TooltipTrigger>
+                              )}
+                            </div>
+                            <div className="mt-2 overflow-x-auto rounded bg-muted p-3 text-sm">
+                              {answer}
+                            </div>
+                          </div>
+                        );
+                      })
+                    )}
+                  </div>
+                );
+              })()}
 
-                                {requiredUnanswered && (
-                                    <TooltipContent>
-                                        {dict.applicationpage.submit_application_tooltip}
-                                    </TooltipContent>
-                                )}
-                            </Tooltip>
-                        </TooltipProvider>
-                    </div>
-                </DialogContent>
-            </Dialog>
-        </>
-    )
+            {selectedRoleIds.map((roleId) => {
+              if (roleId === "general") return null;
+
+              const qas = questionsAndAnswersByRole.get(roleId);
+              const role = roles?.find((r) => String(r.id) === String(roleId));
+
+              return (
+                <div key={roleId} className="mb-6">
+                  <h3 className="text-lg font-bold sm:text-xl">
+                    {role?.name ?? `Role ${roleId}`}
+                  </h3>
+                  {!qas || qas.length === 0 ? (
+                    <p>This role has no questions</p>
+                  ) : (
+                    qas.map((qa) => {
+                      const answer = renderAnswerPreview(qa);
+                      return (
+                        <div key={qa.question_id} className="mb-2">
+                          <div className="flex items-start gap-1">
+                            <h4 className="text-sm font-semibold sm:text-base">
+                              {qa.text}
+                            </h4>
+                            {qa.required && (
+                              <div className="text-destructive font-bold">
+                                *
+                              </div>
+                            )}
+                          </div>
+                          <div className="mt-2 overflow-x-auto rounded bg-muted p-3 text-sm">
+                            {answer}
+                          </div>
+                        </div>
+                      );
+                    })
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <div className="sticky bottom-0 z-10 border-t bg-background p-4">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-block w-full">
+                    <Button
+                      className="w-full rounded-lg border border-primary bg-primary text-primary-foreground transition-all hover:-translate-y-0.5 hover:brightness-110 active:translate-y-0 active:brightness-100 disabled:opacity-50 disabled:cursor-not-allowed"
+                      type="button"
+                      disabled={requiredUnanswered || percentageInvalid}
+                      onClick={() => handleSubmit()}
+                    >
+                      {dict.applicationpage.submit_application}
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+
+                {(requiredUnanswered || percentageInvalid) && (
+                  <TooltipContent>
+                    {dict.applicationpage.submit_application_tooltip}
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            </TooltipProvider>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
 }

--- a/frontend-nextjs/src/components/application-answer/role-card.tsx
+++ b/frontend-nextjs/src/components/application-answer/role-card.tsx
@@ -15,6 +15,9 @@ export function RoleCard({
   selected,
   drag,
   onClick,
+  percentage,
+  onPercentageChange,
+  percentageInvalid,
   dict
 }: {
   role: RoleDetails;
@@ -23,7 +26,19 @@ export function RoleCard({
   drag: DraggableProvided;
   dict: any;
   onClick?: () => void;
+  percentage?: number;
+  onPercentageChange?: (value: number) => void;
+  percentageInvalid?: boolean;
 }) {
+  const fillWidth = selected ? Math.min(Math.max(percentage ?? 0, 0), 100) : 0;
+
+  const stopDragPropagation = {
+    onClick: (e: React.MouseEvent) => e.stopPropagation(),
+    onMouseDown: (e: React.MouseEvent) => e.stopPropagation(),
+    onPointerDown: (e: React.PointerEvent) => e.stopPropagation(),
+    onTouchStart: (e: React.TouchEvent) => e.stopPropagation(),
+  };
+
   return (
     <div
       ref={drag?.innerRef}
@@ -32,11 +47,23 @@ export function RoleCard({
       title="draggable"
       onClick={onClick}
       className={`
-        p-3 rounded-lg border-2 transition-all cursor-pointer bg-card
+        relative overflow-hidden p-3 rounded-lg border-2 transition-all cursor-pointer bg-card
         ${selected ? "border-primary" : "border-border hover:border-primary"}
       `}
     >
-      <div className="flex items-center justify-between">
+      {selected && (
+        <div
+          className="absolute inset-x-0 bottom-0 h-2 bg-muted"
+          aria-hidden="true"
+        >
+          <div
+            className="h-full bg-primary transition-all duration-200"
+            style={{ width: `${fillWidth}%` }}
+          />
+        </div>
+      )}
+
+      <div className="relative flex items-center justify-between">
         <div className="flex items-center gap-2 min-w-0">
           <div
             className="cursor-grab text-muted-foreground select-none"
@@ -62,14 +89,27 @@ export function RoleCard({
             </Tooltip>
           )}
 
-          <span
-            className={`text-xs px-2 py-1 rounded-full ${selected
-              ? "bg-accent text-accent-foreground"
-              : "bg-muted text-muted-foreground"
-              }`}
-          >
-            {selected ? dict.common.selected : dict.common.select}
-          </span>
+          {selected && (
+            <div className="flex items-center gap-1" {...stopDragPropagation}>
+              <input
+                type="number"
+                min={0}
+                max={100}
+                value={percentage ?? 0}
+                onChange={(e) => onPercentageChange?.(Number(e.target.value))}
+                className={`w-14 rounded-full border bg-background px-2 py-1 text-xs text-right [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none ${
+                  percentageInvalid ? "border-destructive text-destructive" : "border-border"
+                }`}
+              />
+              <span className="text-xs text-muted-foreground">%</span>
+            </div>
+          )}
+
+          {!selected && (
+            <span className="text-xs px-2 py-1 rounded-full bg-muted text-muted-foreground">
+              {dict.common.select}
+            </span>
+          )}
         </div>
       </div>
     </div>

--- a/frontend-nextjs/src/components/application-answer/role-percentage-bar.tsx
+++ b/frontend-nextjs/src/components/application-answer/role-percentage-bar.tsx
@@ -1,0 +1,108 @@
+import { RoleDetails } from "@/models/campaign";
+
+export default function RolePercentageBar({
+  selectedRoleIds,
+  rolePercentages,
+  roles,
+  totalPercentage,
+  percentageInvalid,
+  dict,
+}: {
+  selectedRoleIds: string[];
+  rolePercentages: Record<string, number>;
+  roles: RoleDetails[] | undefined;
+  totalPercentage: number;
+  percentageInvalid: boolean;
+  dict: any;
+}) {
+  if (selectedRoleIds.length === 0) return null;
+
+  // when the total exceeds 100, scale everything down so the bar
+  // still fills exactly one container width instead of overflowing
+  const scale = totalPercentage > 100 ? 100 / totalPercentage : 1;
+
+  let running = 0;
+  const segments = selectedRoleIds.map((roleId, index) => {
+    const pct = rolePercentages[roleId] ?? 0;
+    const start = running;
+    running += pct;
+    const end = running;
+    return {
+      roleId,
+      pct,
+      index,
+      displayStart: start * scale,
+      displayEnd: end * scale,
+    };
+  });
+
+  return (
+    <div className="mb-6">
+      <div className="mb-2">
+        <h3 className="text-lg font-bold sm:text-xl">
+          {dict.applicationpage.selected_roles}
+        </h3>
+        {percentageInvalid && (
+          <p className="mt-1 text-right text-xs font-medium text-destructive sm:text-sm">
+            {dict.applicationpage.preference_total_error.replace(
+              "{total}",
+              String(totalPercentage),
+            )}
+          </p>
+        )}
+      </div>
+      <div className="relative h-8 w-full overflow-hidden rounded-full border-2 border-primary bg-background">
+        {segments.map(({ roleId, pct, displayStart, displayEnd }) =>
+          pct <= 0 ? null : (
+            <div
+              key={roleId}
+              style={{
+                left: `${displayStart}%`,
+                width: `${displayEnd - displayStart}%`,
+              }}
+              className={`absolute inset-y-0 bg-violet-50 ${
+                displayEnd < 100 ? "border-r-2 border-primary" : ""
+              }`}
+            />
+          ),
+        )}
+        {segments.map(({ roleId, pct, displayStart, displayEnd }) =>
+          pct <= 0 ? null : (
+            <div
+              key={`label-${roleId}`}
+              style={{
+                left: `${displayStart}%`,
+                width: `${displayEnd - displayStart}%`,
+              }}
+              className="absolute inset-y-0 flex items-center justify-center overflow-hidden"
+            >
+              <span className="truncate px-1 text-lg font-semibold sm:text-xl">
+                {pct}%
+              </span>
+            </div>
+          ),
+        )}
+      </div>
+      <div className="relative mt-2 h-5">
+        {segments.map(({ roleId, pct, displayStart, displayEnd }) => {
+          if (pct <= 0) return null;
+          const role = roles?.find((r) => String(r.id) === String(roleId));
+          return (
+            <div
+              key={`name-${roleId}`}
+              style={{
+                left: `${displayStart}%`,
+                width: `${displayEnd - displayStart}%`,
+              }}
+              className="absolute inset-y-0 flex items-center justify-center overflow-hidden text-center"
+            >
+              <p className="truncate text-sm font-semibold sm:text-base">
+                {role?.name ?? `Role ${roleId}`}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend-nextjs/src/components/application-answer/role-selector.tsx
+++ b/frontend-nextjs/src/components/application-answer/role-selector.tsx
@@ -1,4 +1,9 @@
-import { DragDropContext, Droppable, Draggable, type DropResult } from "@hello-pangea/dnd";
+import {
+  DragDropContext,
+  Droppable,
+  Draggable,
+  type DropResult,
+} from "@hello-pangea/dnd";
 import { CampaignRole, RoleDetails } from "@/models/campaign";
 import { RoleCard } from "./role-card";
 
@@ -7,107 +12,147 @@ export default function RoleSelector({
   maxRolesPerApplication,
   selectedRoleIds,
   onChangeSelectedRoles,
+  rolePercentages,
+  onChangeRolePercentage,
   applicationId,
-  dict
+  dict,
 }: {
   roles: RoleDetails[] | undefined;
-  maxRolesPerApplication: number | null | undefined,
+  maxRolesPerApplication: number | null | undefined;
   selectedRoleIds: string[];
   onChangeSelectedRoles: (next: string[]) => void;
+  rolePercentages: Record<string, number>;
+  onChangeRolePercentage: (campaignRoleId: string, value: number) => void;
   applicationId: string;
   dict: any;
 }) {
-    const handleDragEnd = async ({ source, destination, draggableId }: DropResult) => {
-      if (!destination) return;
-      const to = destination.droppableId;
-      const from = source.droppableId;
-      let newOrder = [...selectedRoleIds];
+  const handleDragEnd = async ({
+    source,
+    destination,
+    draggableId,
+  }: DropResult) => {
+    if (!destination) return;
+    const to = destination.droppableId;
+    const from = source.droppableId;
+    let newOrder = [...selectedRoleIds];
 
-      if (to === "selected-roles" && from === "selected-roles") {
-        const [moved] = newOrder.splice(source.index, 1);
-        newOrder.splice(destination.index, 0, moved);
-        onChangeSelectedRoles(newOrder);
+    if (to === "selected-roles" && from === "selected-roles") {
+      const [moved] = newOrder.splice(source.index, 1);
+      newOrder.splice(destination.index, 0, moved);
+      onChangeSelectedRoles(newOrder);
+      return;
+    }
+
+    if (to === "selected-roles" && from === "available-roles") {
+      if (
+        maxRolesPerApplication &&
+        selectedRoleIds.length + 1 > maxRolesPerApplication
+      )
         return;
-      }
+      newOrder.splice(destination.index, 0, draggableId);
+      onChangeSelectedRoles(newOrder);
+      return;
+    }
 
-      if (to === "selected-roles" && from === "available-roles") {
-        if (maxRolesPerApplication && selectedRoleIds.length + 1 > maxRolesPerApplication) return;
-        newOrder.splice(destination.index, 0, draggableId);
-        onChangeSelectedRoles(newOrder);
-        return;
-      }
+    if (to === "available-roles" && from === "selected-roles") {
+      newOrder = newOrder.filter((id) => id !== draggableId);
+      onChangeSelectedRoles(newOrder);
+      return;
+    }
+  };
 
-      if (to === "available-roles" && from === "selected-roles") {
-        newOrder = newOrder.filter((id) => id !== draggableId);
-        onChangeSelectedRoles(newOrder);
-        return;
-      }
-    };
+  const availableRoles = roles?.filter(
+    (role) => !selectedRoleIds.includes(String(role.id)),
+  );
 
-    const availableRoles = roles?.filter(
-        (role) => !selectedRoleIds.includes(String(role.id))
-    );
+  const totalPercentage = selectedRoleIds.reduce(
+    (sum, id) => sum + (rolePercentages[id] ?? 0),
+    0,
+  );
+  const percentageInvalid =
+    selectedRoleIds.length > 0 && totalPercentage !== 100;
 
-    return (
+  return (
     <div className="w-full rounded-xl border bg-card p-4 shadow-sm xl:sticky xl:top-6">
       <div className="mb-4 flex flex-wrap items-end justify-between gap-2">
-        <h2 className="text-lg font-semibold sm:text-xl">{dict.common.roles}</h2>
-        {
-          maxRolesPerApplication && (
-            <p className="text-sm text-muted-foreground">
-                {dict.applicationpage.max_roles.replace(
-                  "{roles}",
-                  String(maxRolesPerApplication)
-                )}
-            </p>
-          )
-        }
+        <h2 className="text-lg font-semibold sm:text-xl">
+          {dict.common.roles}
+        </h2>
+        {maxRolesPerApplication && (
+          <p className="text-sm text-muted-foreground">
+            {dict.applicationpage.max_roles.replace(
+              "{roles}",
+              String(maxRolesPerApplication),
+            )}
+          </p>
+        )}
       </div>
       <DragDropContext onDragEnd={handleDragEnd}>
-        <div className="space-y-6">
+        <div className="space-y-4">
           {/* Selected roles (draggable & reorderable) */}
-           <div>
-             <h3 className="mb-1 text-sm font-semibold text-foreground">{dict.applicationpage.selected_roles}</h3>
-             <p className="text-xs text-muted-foreground">{dict.applicationpage.drag_to_reorder}</p>
-           </div>
-          <Droppable droppableId="selected-roles">
-            {(provided) => (
-              <div
-                ref={provided.innerRef}
-                {...provided.droppableProps}
-                className="min-h-[44px] space-y-2 rounded-lg border-2 border-dashed border-primary/40 bg-primary/5 p-2"
-              >
-                {selectedRoleIds.length === 0 && (
-                    <div className="text-sm text-muted-foreground px-2 py-1">{dict.applicationpage.empty_selected_roles}</div>
-                )}
-                {selectedRoleIds.map((id, index) => {
-                  const role = roles?.find((r) => String(r.id) === id);
-                  if (!role) return null;
-                  const selected = true;
-                  return (
-                    <Draggable
-                      key={id}
-                      draggableId={id}
-                      index={index}
-                    >
-                      {(drag) => (
-                        <RoleCard
-                          role={role}
-                          index={index}
-                          selected={true}
-                          drag={drag}
-                          dict={dict}
-                        />
-                      )}
-                    </Draggable>
-                  );
-                })}
-                {provided.placeholder}
-              </div>
-            )}
-          </Droppable>
-
-          <h3 className="mb-2 text-sm font-semibold text-foreground">{dict.applicationpage.available_roles}</h3>
+          <div>
+            <h3 className="mb-1 text-sm font-semibold text-foreground">
+              {dict.applicationpage.selected_roles}
+            </h3>
+            <p className="text-xs text-muted-foreground">
+              {dict.applicationpage.drag_to_reorder}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              {dict.applicationpage.unselecting_role}
+            </p>
+          </div>
+          <div className="mb-2">
+            <Droppable droppableId="selected-roles">
+              {(provided) => (
+                <div
+                  ref={provided.innerRef}
+                  {...provided.droppableProps}
+                  className="min-h-[44px] space-y-2 rounded-lg border-2 border-dashed border-primary/40 bg-primary/5 p-2"
+                >
+                  {selectedRoleIds.length === 0 && (
+                    <div className="text-sm text-muted-foreground px-2 py-1">
+                      {dict.applicationpage.empty_selected_roles}
+                    </div>
+                  )}
+                  {selectedRoleIds.map((id, index) => {
+                    const role = roles?.find((r) => String(r.id) === id);
+                    if (!role) return null;
+                    const selected = true;
+                    return (
+                      <Draggable key={id} draggableId={id} index={index}>
+                        {(drag) => (
+                          <RoleCard
+                            role={role}
+                            index={index}
+                            selected={true}
+                            drag={drag}
+                            dict={dict}
+                            percentage={rolePercentages[id]}
+                            onPercentageChange={(value) =>
+                              onChangeRolePercentage(id, value)
+                            }
+                            percentageInvalid={percentageInvalid}
+                          />
+                        )}
+                      </Draggable>
+                    );
+                  })}
+                  {provided.placeholder}
+                </div>
+              )}
+            </Droppable>
+          </div>
+          {percentageInvalid && (
+            <p className="text-xs text-red-500 text-right">
+              {dict.applicationpage.preference_total_error.replace(
+                "{total}",
+                String(totalPercentage),
+              )}
+            </p>
+          )}
+          <h3 className="mb-2 text-sm font-semibold text-foreground">
+            {dict.applicationpage.available_roles}
+          </h3>
           <Droppable droppableId="available-roles">
             {(provided) => (
               <div
@@ -116,7 +161,9 @@ export default function RoleSelector({
                 className="min-h-[44px] space-y-2 rounded-lg border-2 border-dashed border-muted bg-muted/20 p-2"
               >
                 {selectedRoleIds.length === roles?.length && (
-                    <div className="text-sm text-muted-foreground px-2 py-1">{dict.applicationpage.empty_available_roles}</div>
+                  <div className="text-sm text-muted-foreground px-2 py-1">
+                    {dict.applicationpage.empty_available_roles}
+                  </div>
                 )}
                 {availableRoles?.map((role, index) => (
                   <Draggable

--- a/frontend-nextjs/src/dictionaries/en.json
+++ b/frontend-nextjs/src/dictionaries/en.json
@@ -69,6 +69,8 @@
         "empty_available_roles": "All roles selected",
         "selected_roles": "Selected Roles",
         "available_roles": "Available Roles",
+        "preference_total_error": "Your total is {total}/100 it should be 100%",
+        "unselecting_role": "Unselecting this role will remove all answers for it.",
         "no_role_specific_qs": "No role-specific questions",
         "your_answer": "Your answer",
         "no_answer": "No answer",

--- a/frontend-nextjs/src/dictionaries/zh.json
+++ b/frontend-nextjs/src/dictionaries/zh.json
@@ -67,6 +67,8 @@
         "empty_available_roles": "NOT TRANSLATED SORRY CN DEVSOC COMMUNITY ;-;",
         "selected_roles": "NOT TRANSLATED SORRY CN DEVSOC COMMUNITY ;-;",
         "available_roles": "NOT TRANSLATED SORRY CN DEVSOC COMMUNITY ;-;",
+        "preference_total_error": "NOT TRANSLATED SORRY CN DEVSOC COMMUNITY ;-;",
+        "unselecting_role": "NOT TRANSLATED SORRY CN DEVSOC COMMUNITY ;-;",
         "no_role_specific_qs": "NOT TRANSLATED SORRY CN DEVSOC COMMUNITY ;-;",
         "your_answer": "NOT TRANSLATED SORRY CN DEVSOC COMMUNITY ;-;",
         "no_answer": "NOT TRANSLATED SORRY CN DEVSOC COMMUNITY ;-;"

--- a/frontend-nextjs/src/lib/api.ts
+++ b/frontend-nextjs/src/lib/api.ts
@@ -95,10 +95,20 @@ export async function apiRequest<T>(
       }
     }
 
+    let backendMessage: string | undefined;
+    try {
+      const errorBody = await response.json();
+      if (typeof errorBody?.error === "string") {
+        backendMessage = errorBody.error;
+      }
+    } catch {
+      // if response body wasn't JSON, fall back to the generic message below
+    }
+
     throw new ApiError(
       response.status,
       response.statusText,
-      `API request failed: ${method} ${path}`
+      backendMessage || `API request failed: ${method} ${path}`
     );
   }
 

--- a/frontend-nextjs/src/models/application.ts
+++ b/frontend-nextjs/src/models/application.ts
@@ -19,7 +19,7 @@ export type ApplicationStatus = "Pending" | "Rejected" | "Successful" | "Intervi
 export interface ApplicationAppliedRoleDetails {
   campaign_role_id: string;
   role_name: string;
-  preference: number;
+  preference_percentage: number;
 }
 
 export async function createOrGetApplication(


### PR DESCRIPTION
- rename `preference` → `preference_percentage` on `application_roles` (DB migration, backend models/queries, frontend types). So now role preference is a percentage weighting instead of a rank
- add a DB trigger that fires when an application is submitted and rejects it if the role percentages don't sum to 100 (a trigger rather than a CHECK constraint since the sum spans multiple rows)
- add a percentage input to each selected role card, with validation (percentages auto-split evenly when the selection changes, invalid values are highlighted, and submission is blocked until the total is exactly 100)
- show a role-preference percentage bar in the applicant's review card and in the organisation's application review panel
- fix a bug where unselecting a role left its question tab active, so now the view falls back to the General tab

role selection: 
<img width="346" height="411" alt="image" src="https://github.com/user-attachments/assets/dd1a80e6-c2dc-4b02-b29d-c1f6710bbbf8" />

review card: 
<img width="486" height="136" alt="image" src="https://github.com/user-attachments/assets/769e9f12-c2b0-4679-b605-938dde921bdf" />

organisation panel: 
<img width="3014" height="1652" alt="image" src="https://github.com/user-attachments/assets/287a0dd3-c68a-4722-bdcb-ebe9f4820f92" />

